### PR TITLE
use cors package for cors

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "basic-auth-connect": "^1.0.0",
     "bluebird": "^3.1.1",
     "body-parser": "^1.14.2",
+    "cors": "^2.7.1",
     "dataloader": "^1.1.0",
     "deasync": "^0.1.4",
     "express": "^4.13.3",

--- a/server.js
+++ b/server.js
@@ -7,6 +7,7 @@ import bodyParser from "body-parser"
 import forceSSL from "express-force-ssl"
 import morgan from "morgan"
 import auth from "basic-auth"
+import cors from "cors"
 
 // let PORT = process.env.DOCKER_HOST ? 80 : 8080
 let PORT = process.env.PORT || 80
@@ -47,30 +48,11 @@ app.use(bodyParser.urlencoded({
 
 app.use(bodyParser.json())
 
-
-
-
-
-// Add headers
-app.use((req, res, next) => {
-
-  // Website you wish to allow to connect
-  res.setHeader('Access-Control-Allow-Origin', 'http://localhost:3000');
-
-  // Request methods you wish to allow
-  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS, PUT, PATCH, DELETE');
-
-  // Request headers you wish to allow
-  res.setHeader('Access-Control-Allow-Headers', 'X-Requested-With,content-type');
-
-  // Set to true if you need the website to include cookies in the requests sent
-  // to the API (e.g. in case you use sessions)
-  res.setHeader('Access-Control-Allow-Credentials', true);
-
-  // Pass to next layer of middleware
-  next();
-
-});
+const corsOptions = {
+  origin: "http://localhost:3000",
+  credentials: true
+}
+app.use(cors(corsOptions))
 
 
 app.use("/", graphqlHTTP(() => ({


### PR DESCRIPTION
Using apollo-client with heighliner in a blank meteor package was causing a 405 error "Method Not Allowed":

```
Fetch API cannot load http://localhost:8888/. Response for preflight has invalid HTTP status code 405
```

Here are the headers:

```
OPTIONS / HTTP/1.1
Host: localhost:8888
Accept: */*
Accept-Encoding: gzip, deflate, sdch
Accept-Language: en-US,en;q=0.8
Access-Control-Request-Headers: accept, content-type
Access-Control-Request-Method: POST
Origin: http://localhost:3000
Referer: http://localhost:3000/
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.87 Safari/537.36
X-DevTools-Emulate-Network-Conditions-Client-Id: 41E56F16-D515-4DFE-AB1D-84A2CF13A296

HTTP/1.1 405 Method Not Allowed
Access-Control-Allow-Credentials: true
Access-Control-Allow-Headers: X-Requested-With,content-type
Access-Control-Allow-Methods: GET, POST, OPTIONS, PUT, PATCH, DELETE
Access-Control-Allow-Origin: http://localhost:3000
Allow: GET, POST
Connection: keep-alive
Content-Length: 71
Content-Type: application/json; charset=utf-8
Date: Mon, 28 Mar 2016 03:55:39 GMT
ETag: W/"47-IAPvQmIsu2oEs4RWHtX1XA"
X-Powered-By: Express
```

I tried a few different setups, and ended up just trying the [cors](https://github.com/expressjs/cors) package, and it works. 

```
OPTIONS / HTTP/1.1
Host: localhost:8888
Accept: */*
Accept-Encoding: gzip, deflate, sdch
Accept-Language: en-US,en;q=0.8
Access-Control-Request-Headers: accept, content-type
Access-Control-Request-Method: POST
Origin: http://localhost:3000
Referer: http://localhost:3000/
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.87 Safari/537.36
X-DevTools-Emulate-Network-Conditions-Client-Id: 41E56F16-D515-4DFE-AB1D-84A2CF13A296

HTTP/1.1 204 No Content
Access-Control-Allow-Credentials: true
Access-Control-Allow-Headers: accept, content-type
Access-Control-Allow-Methods: GET,HEAD,PUT,PATCH,POST,DELETE
Access-Control-Allow-Origin: http://localhost:3000
Connection: keep-alive
Date: Mon, 28 Mar 2016 04:00:02 GMT
Vary: Origin
X-Powered-By: Express
```

It looks like they are only adding some headers for the preflight OPTIONS request: https://github.com/expressjs/cors/blob/master/lib/index.js#L156-L164

I tried removing the extra headers I'm seeing, but that didn't work.

Anyways, this works great now.
