### PR TITLE
StreamURL to embedCode in Heighliner for Live Video

### DIFF
--- a/ee/mysql.js
+++ b/ee/mysql.js
@@ -388,7 +388,8 @@ const getLiveFeed = (site, ttl, cache) => {
         },
         live: false,
         media: {
-          streamUrl: null
+          streamUrl: null,
+          embedCode: null
         }
       };
 
@@ -414,7 +415,7 @@ const getLiveFeed = (site, ttl, cache) => {
           content = content.rows[0];
           data.title = content.title;
           data.content.body = content.body;
-          data.media.streamUrl = content.url;
+          data.media.embedCode = content.embedCode;
 
           data.content.images.push({
             cloudfront: content.wideImage,

--- a/ee/mysql.js
+++ b/ee/mysql.js
@@ -388,7 +388,6 @@ const getLiveFeed = (site, ttl, cache) => {
         },
         live: false,
         media: {
-          streamUrl: null,
           embedCode: null
         }
       };

--- a/ee/util/liveContent.sql
+++ b/ee/util/liveContent.sql
@@ -6,13 +6,13 @@ SELECT
   m.col_id_270 AS wideImage,
   m.col_id_271 AS squareImage,
   m.col_id_272 AS tallImage,
-  g.variable_data AS url
+  n.snippet_contents AS embedCode
 FROM
   exp_sites s
   JOIN exp_channel_data d ON d.site_id = s.site_id
   JOIN exp_channel_titles t ON t.channel_id = d.channel_id AND t.entry_id = d.entry_id AND t.site_id = s.site_id
   JOIN exp_matrix_data m ON m.entry_id = d.entry_id AND m.site_id = s.site_id
-  LEFT JOIN exp_global_variables g ON g.variable_name = 'live_stream_url'
+  LEFT JOIN exp_snippets n ON n.snippet_name = 'PUBLIC_EMBED_CODE'
 WHERE
   s.site_name = '${site_name}'
   AND d.channel_id = 4

--- a/schemas/live.js
+++ b/schemas/live.js
@@ -19,7 +19,7 @@ import ContentType from "./shared/EE/content"
 const MediaType = new GraphQLObjectType({
   name: "MediaType",
   fields: () => ({
-    streamUrl: { type: GraphQLString }
+    embedCode: { type: GraphQLString }
   }),
 });
 


### PR DESCRIPTION
- switched `StreamUrl` to `embedCode` to be passed as a prop to the video player.
