### PR TITLE
added syslog to papertrail logging in docker

### DIFF
--- a/.ecs/deploy.sh
+++ b/.ecs/deploy.sh
@@ -31,6 +31,13 @@ make_task_def() {
           "protocol": "http"
         }
       ],
+      "logConfiguration": {
+        "logDriver": "syslog",
+        "options": {
+          "syslog-address": "udp://logs.papertrailapp.com:23588",
+          "tag": "{{.Name}}"
+        }
+      },
       "environment": [
         {
           "name": "NODE_ENV",


### PR DESCRIPTION
Rather than run a separate container just to handling logging I enabled the ECS agents support of sending logs to syslog (something docker already supports).
