### PR TITLE
[WIP] Sermon audio

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -99,11 +99,6 @@ declare module "truncate" {
   export default function(string: string, length: number): string;
 }
 
-declare module "connect-datadog" {
-  export default function(opts: any): any;
-}
-
-
 declare module "raven" {
   export interface IOptions {
     extra?: Object;
@@ -152,4 +147,7 @@ declare module "datadog-metrics" {
   }
   let client: DDog;
   export default client;
+
+declare module "mp3-duration" {
+  export default function(filename: string, callback: any);
 }

--- a/global.d.ts
+++ b/global.d.ts
@@ -147,6 +147,7 @@ declare module "datadog-metrics" {
   }
   let client: DDog;
   export default client;
+}
 
 declare module "mp3-duration" {
   export default function(filename: string, callback: any);

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "moment": "^2.13.0",
     "mongoose": "^4.5.8",
     "morgan": "^1.7.0",
+    "mp3-duration": "^1.0.10",
     "mssql-geoparser": "0.0.1",
     "mysql": "^2.10.2",
     "newrelic": "^1.25.0",

--- a/src/expression-engine/models/content/resolver.ts
+++ b/src/expression-engine/models/content/resolver.ts
@@ -136,6 +136,23 @@ export default {
       const position = Number(exp_channel.exp_channel_fields.tracks.split("_").pop());
       return models.File.getFilesFromContent(entry_id, tracks, position);
     },
+    audio: ({ entry_id, audio, tracks, exp_channel }, _, { models }) => {
+      if (!audio && !tracks) return Promise.all([]);
+      const getAllFiles = [];
+
+      if (audio) {
+        const audioPosition = Number(exp_channel.exp_channel_fields.audio.split("_").pop());
+        getAllFiles.push(models.File.getFilesFromContent(entry_id, audio, audioPosition));
+      }
+
+      if (tracks) {
+        const trackPosition = Number(exp_channel.exp_channel_fields.tracks.split("_").pop());
+        getAllFiles.push(models.File.getFilesFromContent(entry_id, tracks, trackPosition));
+      }
+
+      return Promise.all(getAllFiles)
+        .then(data => flatten(data));
+    },
   },
 
   ContentMeta: {

--- a/src/expression-engine/models/content/resolver.ts
+++ b/src/expression-engine/models/content/resolver.ts
@@ -130,6 +130,7 @@ export default {
         description: "primary",
       }];
     },
+    // deprecated
     tracks: ({ entry_id, tracks, exp_channel }, _, { models }) => {
       if (!tracks) return [];
 

--- a/src/expression-engine/models/content/schema.graphql
+++ b/src/expression-engine/models/content/schema.graphql
@@ -29,7 +29,10 @@ type ContentData {
   tags: [String] # XXX create global tag type
   colors: [ContentColor]
   images: [File]
+
+  # deprecated (use audio field)
   tracks: [File]
+  audio: [File]
   scripture: [ContentScripture]
 }
 

--- a/src/expression-engine/models/files/model.ts
+++ b/src/expression-engine/models/files/model.ts
@@ -125,7 +125,9 @@ export class File extends EE {
             const seconds = Math.round(calcDuration % 60);
             const minutes = Math.round(calcDuration / 60);
             const paddedSeconds = seconds < 10 ? `0${seconds}` : seconds;
-            unlink(tmpFileName);
+
+            // check first in case multiple requests come in before cache
+            if (existsSync(tmpFileName)) unlink(tmpFileName);
             file.duration = `${minutes}:${paddedSeconds}`;
             return resolve(file);
           });

--- a/src/expression-engine/models/files/model.ts
+++ b/src/expression-engine/models/files/model.ts
@@ -98,13 +98,16 @@ export class File extends EE {
     }
   }
 
-  private getDuration(file: any): Promise<any> {
+  private addDuration(file: any): Promise<any> {
     return new Promise((resolve, reject) => {
       const fileName = file.exp_assets_file.file_name;
-      if (fileName.slice(fileName.length - 3) !== "mp3") return null;
+      if (fileName.slice(fileName.length - 3) !== "mp3") return resolve(file);
 
       const duration = file.exp_matrix_datum && this.fuzzyMatchKey(file.exp_matrix_datum, "duration");
-      if (duration) return resolve(duration);
+      if (duration) {
+        file.duration = duration;
+        return resolve(file);
+      }
 
       // create ./tmp/audio directory
       if (!existsSync("./tmp")) mkdirSync("./tmp");
@@ -123,13 +126,15 @@ export class File extends EE {
             const minutes = Math.round(calcDuration / 60);
             const paddedSeconds = seconds < 10 ? `0${seconds}` : seconds;
             unlink(tmpFileName);
-            return resolve(`${minutes}:${paddedSeconds}`);
+            file.duration = `${minutes}:${paddedSeconds}`;
+            return resolve(file);
           });
         });
       }).on("error", (error) => {
         console.log(error.message); // tslint:disable-line
         unlink(tmpFileName);
-        resolve(null);
+        file.duration = null;
+        return reject(file);
       });
     });
   }
@@ -177,12 +182,13 @@ export class File extends EE {
       ],
     })
       .then(data => data.map(x => x.exp_assets_selection))
+      .then(data => (Promise.all(data.map(file => ( this.addDuration(file) )))))
       .then(data => data.map(x => (merge(
         {
           file_id: x.file_id,
           fileLabel: x.exp_matrix_col && x.exp_matrix_col.col_label,
           title: x.exp_matrix_datum && this.fuzzyMatchKey(x.exp_matrix_datum, "title"),
-          duration: this.getDuration(x),
+          duration: x.duration,
         },
         this.generateFileName(x.exp_assets_file)
       ))))

--- a/test/expression-engine/models/content/resolver.spec.ts
+++ b/test/expression-engine/models/content/resolver.spec.ts
@@ -49,3 +49,101 @@ test("`ContentScripture` returns book and passage", t => {
   t.deepEqual(book, sampleData.contentScripture.book);
   t.deepEqual(passage, sampleData.contentScripture.passage);
 });
+
+// XXX test all of this resolver
+
+test("`ContentData` returns blank array if no audio or tracks", async (t) => {
+  const { ContentData } = Resolver;
+  const mockData = {
+    entry_id: "testId",
+    audio: null,
+    tracks: null,
+    exp_channel: {},
+  };
+  const models = {};
+
+  await ContentData.audio(mockData, null, { models });
+});
+
+test("`ContentData` fetches audio files if audio", async (t) => {
+  const { ContentData } = Resolver;
+  const mockData = {
+    entry_id: "testId",
+    audio: "audio.mp3",
+    tracks: null,
+    exp_channel: {
+      exp_channel_fields: {
+        audio: "test_field_123",
+      },
+    },
+  };
+  const models = {
+    File: {
+      getFilesFromContent: (entry_id, audio, audioPosition) => {
+        t.is(entry_id, mockData.entry_id);
+        t.is(audio, mockData.audio);
+        t.is(audioPosition, Number(mockData.exp_channel.exp_channel_fields.audio.split("_").pop()));
+      },
+    },
+  };
+
+  await ContentData.audio(mockData, null, { models });
+});
+
+test("`ContentData` fetches tracks files if tracks", async (t) => {
+  const { ContentData } = Resolver;
+  const mockData = {
+    entry_id: "testId",
+    audio: null,
+    tracks: "audio.mp3",
+    exp_channel: {
+      exp_channel_fields: {
+        tracks: "test_field_789",
+      },
+    },
+  };
+  const models = {
+    File: {
+      getFilesFromContent: (entry_id, tracks, trackPosition) => {
+        t.is(entry_id, mockData.entry_id);
+        t.is(tracks, mockData.tracks);
+        t.is(trackPosition, Number(mockData.exp_channel.exp_channel_fields.tracks.split("_").pop()));
+      },
+    },
+  };
+
+  await ContentData.audio(mockData, null, { models });
+});
+
+test("`ContentData` fetches audio and tracks files if both", async (t) => {
+  const { ContentData } = Resolver;
+  const mockData = {
+    entry_id: "testId",
+    audio: "audio.mp3",
+    tracks: "track.mp3",
+    exp_channel: {
+      exp_channel_fields: {
+        audio: "test_field_123",
+        tracks: "test_field_789",
+      },
+    },
+  };
+  let count = 0;
+  const models = {
+    File: {
+      getFilesFromContent: (entry_id, thing, thingPosition) => {
+        count++;
+        t.is(entry_id, mockData.entry_id);
+        t.true([mockData.audio, mockData.tracks].indexOf(thing) > -1);
+        const splitField = thing === mockData.audio ?
+          Number(mockData.exp_channel.exp_channel_fields.audio.split("_").pop()) :
+          Number(mockData.exp_channel.exp_channel_fields.tracks.split("_").pop())
+        ;
+        t.is(thingPosition, splitField);
+      },
+    },
+  };
+
+  await ContentData.audio(mockData, null, { models });
+  t.is(count, 2);
+});


### PR DESCRIPTION
This will bring:
1. sermon audio
2. dynamic mp3 duration calculation

Cache misses are going to be painful. Not only do we have the issue of waiting for the file to download and then the file to be scanned, we have the issue of multiple people making requests before the dynamic duration data can be cached. Currently, this actually sort of works, but it still requires a scan of the file each time.

I'm wondering if it wouldn't be a better case scenario to require duration for audio in EE going forward, and then run a script against the EE database to set the duration for old entries? This would drastically cut down on cache miss times, and the complexity needed to handle multiple cache misses.

If not, we will need some kind of queuing or event based system to handle multiple cache misses, so that the file is only downloaded and scanned one time.
