### PR TITLE
Empty Feed Fixes

### DIFF
--- a/src/expression-engine/models/content/__tests__/resolver.spec.ts
+++ b/src/expression-engine/models/content/__tests__/resolver.spec.ts
@@ -128,7 +128,7 @@ it("`Query` feed should lower case, convert, and exclude Series and Music", () =
   const models = {
     Content: {
       find: (object, cache) => {
-        expect(object.channel_name).toEqual({ $or: difference(eeChannels, ["series_newspring", "albums_newspring"]) });
+        expect(object.channel_name).toEqual({ $or: difference(eeChannels, ["series_newspring", "newspring_albums"]) });
       },
     },
   };

--- a/src/expression-engine/models/content/resolver.ts
+++ b/src/expression-engine/models/content/resolver.ts
@@ -18,7 +18,7 @@ export default {
     },
 
     feed(_, { excludeChannels, limit, skip, status, cache }, { models }) {
-      let channels = [
+      const allChannels = [
         "devotionals",
         "articles",
         "series_newspring",
@@ -40,12 +40,16 @@ export default {
         .map(x => x.toLowerCase())
         .map(x => {
           if (x === "series") return "series_newspring";
-          if (x === "music") return "albums_newspring";
+          if (x === "music") return "newspring_albums";
           return x;
         });
 
       // only include what user hasn't excluded
-      channels = difference(channels, excludeChannels);
+      let channels = difference(allChannels, excludeChannels);
+      // ensure channels aren't empty
+      if (channels.length === 0) {
+        channels = allChannels;
+      }
       return models.Content.find({
         channel_name: { $or: channels }, offset: skip, limit, status,
       }, cache);


### PR DESCRIPTION
1. updates the name of the albums channel so it can be excluded from the feed
2. ensures the channels cannot be empty so we don't accidentally pull all channels
