### PR TITLE
Add null response for invalid content lookup

### DIFF
--- a/src/expression-engine/models/content/__tests__/model.js
+++ b/src/expression-engine/models/content/__tests__/model.js
@@ -38,4 +38,11 @@ describe("findByUrlTitle", () => {
     expect(createGlobalId).toBeCalledWith("1123", "Content");
   });
 
+  it("should return null for invalid lookup", async () => {
+    createGlobalId.mockReset();
+    Model.cache.get = jest.fn(() => ({}));
+    const res = await Model.findByUrlTitle("articles","harambe");
+    expect(res).toEqual(null);
+  });
+
 });

--- a/src/expression-engine/models/content/model.js
+++ b/src/expression-engine/models/content/model.js
@@ -426,6 +426,7 @@ export class Content extends EE {
       }, { ttl: 3600, cache: false })
     );
 
+    if(!results || !results.entry_id) return null;
     return createGlobalId(results.entry_id, this.__type);
   };
 


### PR DESCRIPTION
- checks for results from cache lookup/query and if they don't exist (lookup error) or if the entry_id key isn't there (bad urlTitle/channel) returns null
- Tested it too

<img width="947" alt="screen shot 2017-01-24 at 11 29 43 am" src="https://cloud.githubusercontent.com/assets/9259509/22256469/de81f156-e228-11e6-93d1-697cec5a62c3.png">
