### PR TITLE
Removed null results from mongo call

### DIFF
--- a/src/rock/models/likes/__tests__/model.js
+++ b/src/rock/models/likes/__tests__/model.js
@@ -194,6 +194,18 @@ describe("Like", () => {
       const res = await like.getRecentlyLiked({limit: 99, skip: 0, cache: null}, "harambe", mockData.nodeModel);
       expect(res).toEqual([{entryId: "abc"}, {entryId: "def"}]);
     });
+    it("handles null results in mongo return array", async () => {
+      mongo.distinct.mockReturnValueOnce(["123", undefined, "456"]);
+      mockData.nodeModel.get.mockReturnValueOnce({entryId: "abc"});
+      mockData.nodeModel.get.mockReturnValueOnce({entryId: "def"});
+      mockData.nodeModel.get.mockReturnValueOnce({entryId: "ghi"});
+      defaultCache.get.mockImplementationOnce((a, b) => b());
+
+      const res = await like.getRecentlyLiked({limit: 99, skip: 0, cache: null}, "harambe", mockData.nodeModel);
+      expect(res).toEqual([{entryId: "abc"}, {entryId: "def"}]);
+      expect(res.length).toEqual(2);
+      mongo.distinct.mockReset();
+    });
     it("returns null if no results", async () => {
       mongo.distinct.mockReturnValueOnce(null);
       defaultCache.get.mockImplementationOnce((a, b) => b());

--- a/src/rock/models/likes/model.js
+++ b/src/rock/models/likes/model.js
@@ -72,7 +72,10 @@ export class Like {
     });
 
     if(!entryIds || !entryIds.length) return null;
-    return entryIds.map(like => nodeModel.get(like));
+    return entryIds
+      .filter(x => x) // remove empty entries
+      .map(like => nodeModel.get(like));
+
   }
 
   async toggleLike(nodeId, userId, nodeModel) {


### PR DESCRIPTION
- I believe the problem was when mongo returned results from `distinct`, some of them were somehow null. Maybe a data problem? 
- I just added a filter to check for falsy results. 
- Tested it, of course 🎉 