### PR TITLE
Requesting info about a group

### DIFF
--- a/src/rock/models/groups/__tests__/__snapshots__/mutations.js.snap
+++ b/src/rock/models/groups/__tests__/__snapshots__/mutations.js.snap
@@ -1,0 +1,9 @@
+exports[`test should contain mutations 1`] = `
+Array [
+  "requestGroupInfo(
+    groupId: ID!,
+    message: String!,
+    communicationPreference: String!,
+  ): GroupsMutationResponse",
+]
+`;

--- a/src/rock/models/groups/__tests__/model.js
+++ b/src/rock/models/groups/__tests__/model.js
@@ -1,0 +1,128 @@
+
+import { Group } from "../model";
+import {
+  Group as GroupTable,
+  GroupMember as GroupMemberTable,
+} from "../tables";
+
+import {
+  Person as PersonTable
+} from "../../people/tables";
+
+jest.mock("dataloader");
+jest.mock("../tables", () => ({
+  Group: {
+    find: jest.fn(),
+    findOne: jest.fn(),
+  },
+  GroupType: { model: "123" },
+  GroupMember: {
+    findOne: jest.fn(),
+    post: jest.fn(),
+  }
+}));
+jest.mock("../../system/tables", () => ({
+  Attribute: { model: "12345" },
+  AttributeValue: { model: "1234" },
+}));
+jest.mock("../../people/tables", () => ({
+  Person: {
+    fetch: jest.fn(),
+  },
+}));
+
+const mockArgs = { groupId: 1234, message: "harambe", communicationPreference: "phone" };
+
+describe("requestGroupInfo", () => {
+  let groupModel;
+
+  beforeEach(() => {
+    groupModel = new Group();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  })
+
+  it("should return 400 if missing info", async () => {
+    const { requestGroupInfo } = groupModel;
+    const res = await requestGroupInfo({});
+    expect(res.code).toEqual(400);
+  });
+
+  it("should return 404 on failed group lookup", async () => {
+    const { requestGroupInfo } = groupModel;
+    const res = await requestGroupInfo(mockArgs, "person");
+    expect(res.code).toEqual(404);
+  });
+
+  it("should lookup member with proper query and fail if found", async () => {
+    const { requestGroupInfo } = groupModel;
+    GroupTable.findOne.mockReturnValueOnce("hello");
+    GroupMemberTable.findOne.mockReturnValueOnce("yo");
+
+    await requestGroupInfo(mockArgs, {Id: 9999999999});
+    expect(GroupMemberTable.findOne).toHaveBeenCalledWith({
+      where: { GroupId: 1234, PersonId: 9999999999 },
+    });
+  });
+
+  it("should return 400 if user is member of group already", async () => {
+    const { requestGroupInfo } = groupModel;
+    GroupTable.findOne.mockReturnValueOnce("hello");
+    GroupMemberTable.findOne.mockReturnValueOnce("yo");
+
+    const res = await requestGroupInfo(mockArgs, {Id: 9999999999});
+    expect(res.code).toEqual(400);
+  });
+
+  it("should update user's communication preferences", async () => {
+    const { requestGroupInfo } = groupModel;
+    GroupTable.findOne.mockReturnValueOnce("hello");
+
+    await requestGroupInfo(mockArgs, {Id: 9999999999});
+    expect(PersonTable.fetch).toHaveBeenCalledWith(
+      "POST",
+      "attributevalue/9999999999?AttributeKey=CommunicationPreference&AttributeValue=phone",
+      {}
+    );
+  });
+
+  it("should return error if updating communication prefs fails", async () => {
+    const { requestGroupInfo } = groupModel;
+    GroupTable.findOne.mockReturnValueOnce("hello");
+    PersonTable.fetch.mockReturnValueOnce({ status: 400, statusText: "ANGRY" });
+
+    const res = await requestGroupInfo(mockArgs, {Id: 9999999999});
+    expect(res).toEqual({ code: 400, error: "ANGRY", success: false});
+  });
+
+  it("should fail if adding user to group fails", async () => {
+    const { requestGroupInfo } = groupModel;
+    GroupTable.findOne.mockReturnValueOnce("hello");
+    GroupMemberTable.post.mockReturnValueOnce({
+      status: 404,
+      statusText: "BAD BAD BAD",
+    });
+
+    const res = await requestGroupInfo(mockArgs, {Id: 9999999999});
+    expect(res).toEqual({ code: 404, success: false, error: "BAD BAD BAD"});
+  });
+
+  it("should call post if user isn't member of group", async () => {
+    const { requestGroupInfo } = groupModel;
+    GroupTable.findOne.mockReturnValueOnce("hello");
+
+    const res = await requestGroupInfo(mockArgs, {Id: 9999999999});
+    expect(res).toEqual({ code: 200, success: true});
+  });
+
+  it("should return MutationResponse", async () => {
+    const { requestGroupInfo } = groupModel;
+    GroupTable.findOne.mockReturnValueOnce("hello");
+
+    const res = await requestGroupInfo(mockArgs, {Id: 9999999999});
+    //the bare minimum for mutation responses
+    expect(Object.keys(res)).toEqual(["code", "success"]);
+  });
+});

--- a/src/rock/models/groups/__tests__/mutations.js
+++ b/src/rock/models/groups/__tests__/mutations.js
@@ -1,0 +1,6 @@
+
+import mutations from "../mutations";
+
+it("should contain mutations", () => {
+  expect(mutations).toMatchSnapshot();
+});

--- a/src/rock/models/groups/__tests__/resolver.js
+++ b/src/rock/models/groups/__tests__/resolver.js
@@ -1,0 +1,29 @@
+
+import Resolver from "../resolver";
+
+describe("requestGroupInfo", () => {
+  beforeEach(() => {
+
+  });
+
+  it("should return 401 with no person", async () => {
+    const { requestGroupInfo } = Resolver.Mutation;
+    const res = await requestGroupInfo(null, {}, {});
+    expect(res).toEqual({
+      code: 401, error: "Must be logged in to make this request", success: false,
+    });
+  });
+
+  it("should call model function properly if person", async () => {
+    const models = { Group: { requestGroupInfo: jest.fn() } };
+    const { requestGroupInfo } = Resolver.Mutation;
+    await requestGroupInfo(null, {
+      communicationPreference: "banana", groupId: 1234, message: "i miss harambe"
+    }, { models, person:"person" });
+    expect(models.Group.requestGroupInfo).toHaveBeenCalledWith({
+      communicationPreference: "banana", groupId: 1234, message: "i miss harambe"
+    }, "person");
+  });
+
+
+});

--- a/src/rock/models/groups/index.js
+++ b/src/rock/models/groups/index.js
@@ -2,10 +2,12 @@ import schema from "./schema";
 import resolvers from "./resolver";
 import models from "./model";
 import queries from "./queries";
+import mutations from "./mutations";
 
 export default {
   schema,
   resolvers,
   models,
   queries,
+  mutations,
 };

--- a/src/rock/models/groups/model.js
+++ b/src/rock/models/groups/model.js
@@ -16,6 +16,10 @@ import {
 } from "./tables";
 
 import {
+  PhoneNumber as PhoneNumberTable,
+} from "../people/tables";
+
+import {
   Campus as CampusTable,
 } from "../campuses/tables";
 
@@ -406,8 +410,18 @@ async findByAttributesAndQuery({ attributes, query, campuses }, { limit, offset,
 
   }
 
-  async requestGroupInfo() {
-    return null;
+  async requestGroupInfo({ groupId, message, communicationPreference }, person) {
+    /* make sure group exists */
+    const group = await this.getFromId(groupId);
+    // if (!group) return `No group with id ${groupId} found`; // or something
+    if (!group) console.log("AHH IM ANGRY");
+
+    /* make sure user is not member of this group */
+    // TODO
+
+    return null; // XXX for now
+    /* hit REST endpoint to add groupmember with preference and message */
+    //GroupMemberTable.post({});
   }
 }
 

--- a/src/rock/models/groups/model.js
+++ b/src/rock/models/groups/model.js
@@ -405,6 +405,10 @@ async findByAttributesAndQuery({ attributes, query, campuses }, { limit, offset,
     );
 
   }
+
+  async requestGroupInfo() {
+    return null;
+  }
 }
 
 export default {

--- a/src/rock/models/groups/model.js
+++ b/src/rock/models/groups/model.js
@@ -411,16 +411,31 @@ async findByAttributesAndQuery({ attributes, query, campuses }, { limit, offset,
   }
 
   async requestGroupInfo({ groupId, message, communicationPreference }, person) {
+    //error incorrect data
+    if (!groupId || !message || !communicationPreference) return {
+      code: 400, success: false, error: "Insufficient information",
+    };
+
     /* make sure group exists */
-    const group = await this.getFromId(groupId);
-    // if (!group) return `No group with id ${groupId} found`; // or something
-    if (!group) console.log("AHH IM ANGRY");
+    if (!await this.getFromId(groupId)) return {
+      code: 404, success: false, error: `No group with id ${groupId} found`,
+    };
 
     /* make sure user is not member of this group */
-    // TODO
+    const query = {
+      where: {
+        GroupId: groupId,
+        PersonId: person.Id,
+        GroupMemberStatus: 1,
+      }
+    }
 
-    return null; // XXX for now
+    const isMember = await GroupMemberTable.findOne(query);
+    if (isMember) return { code: 400, error: "You are already a member of this group" };
+
     /* hit REST endpoint to add groupmember with preference and message */
+    return { code: 200, success: true };
+
     //GroupMemberTable.post({});
   }
 }

--- a/src/rock/models/groups/model.js
+++ b/src/rock/models/groups/model.js
@@ -429,7 +429,7 @@ async findByAttributesAndQuery({ attributes, query, campuses }, { limit, offset,
         GroupId: groupId,
         PersonId: person.Id,
       }
-    }
+    };
 
     const isMember = await GroupMemberTable.findOne(query);
     if (isMember) return { code: 400, error: "You are already a member of this group" };
@@ -456,7 +456,7 @@ async findByAttributesAndQuery({ attributes, query, campuses }, { limit, offset,
       Note: message,
     });
 
-    if (post & post.status >= 400) return {
+    if (post && post.status >= 400) return {
       code: post.status, error: post.statusText, success: false
     };
 

--- a/src/rock/models/groups/mutations.js
+++ b/src/rock/models/groups/mutations.js
@@ -4,5 +4,5 @@ export default [
     groupId: ID!,
     message: String!,
     communicationPreference: String!,
-  ): [GroupsMutationResponse]`
+  ): GroupsMutationResponse`
 ];

--- a/src/rock/models/groups/mutations.js
+++ b/src/rock/models/groups/mutations.js
@@ -4,6 +4,5 @@ export default [
     groupId: ID!,
     message: String!,
     communicationPreference: String!,
-    phone: String,
   ): [GroupsMutationResponse]`
 ];

--- a/src/rock/models/groups/mutations.js
+++ b/src/rock/models/groups/mutations.js
@@ -1,0 +1,9 @@
+
+export default [
+  `requestGroupInfo(
+    groupId: ID!,
+    message: String!,
+    communicationPreference: String!,
+    phone: String,
+  ): [GroupsMutationResponse]`
+];

--- a/src/rock/models/groups/resolver.js
+++ b/src/rock/models/groups/resolver.js
@@ -179,9 +179,7 @@ export default {
       _, { groupId, message, communicationPreference }, { models, person },
     ) => {
       if (!person) return { code: 401, success: false, error: "Must be logged in to make this request" };
-      const res = await models.Group.requestGroupInfo({ groupId, message, communicationPreference }, person);
-      console.log("RESULTS", res);
-      return res;
+      return await models.Group.requestGroupInfo({ groupId, message, communicationPreference }, person);
     },
   },
 

--- a/src/rock/models/groups/resolver.js
+++ b/src/rock/models/groups/resolver.js
@@ -4,6 +4,12 @@ import { geocode } from "google-geocoding";
 import Moment from "moment";
 import { createGlobalId } from "../../../util";
 
+const MutationReponseResolver = {
+  error: ({ error }) => error,
+  success: ({ success, error }) => success || !error,
+  code: ({ code }) => code,
+};
+
 function getPhotoFromTag(tag) {
   const photos = {
     food: "//s3.amazonaws.com/ns.assets/apollos/groups/group-food.jpg",
@@ -168,6 +174,14 @@ export default {
     },
   },
 
+  Mutation: {
+    requestGroupInfo: async (
+      _, { campuses = [], offset, limit, attributes = [], query, clientIp }, { models, ip, person },
+    ) => {
+      return models.Group.requestGroupInfo();
+    },
+  },
+
   GroupMember: {
     id: ({ Id }, _, $, { parentType }) => createGlobalId(Id, parentType.name),
     role: ({ GroupTypeRole }) => GroupTypeRole && GroupTypeRole.Name, // XXX should we expand this?
@@ -272,4 +286,8 @@ export default {
     results: ({ results }) => results,
   },
 
+  GroupsMutationResponse: {
+    ...MutationReponseResolver,
+    group: ({ group }) => group,
+  },
 };

--- a/src/rock/models/groups/resolver.js
+++ b/src/rock/models/groups/resolver.js
@@ -178,12 +178,10 @@ export default {
     requestGroupInfo: async (
       _, { groupId, message, communicationPreference }, { models, person },
     ) => {
-      // error for no person
-      if (!person) return null;
-      //error incorrect data
-      if (!groupId || !message || !communicationPreference) return null;
-
-      return models.Group.requestGroupInfo({ groupId, message, communicationPreference }, person);
+      if (!person) return { code: 401, success: false, error: "Must be logged in to make this request" };
+      const res = await models.Group.requestGroupInfo({ groupId, message, communicationPreference }, person);
+      console.log("RESULTS", res);
+      return res;
     },
   },
 
@@ -293,6 +291,5 @@ export default {
 
   GroupsMutationResponse: {
     ...MutationReponseResolver,
-    group: ({ group }) => group,
   },
 };

--- a/src/rock/models/groups/resolver.js
+++ b/src/rock/models/groups/resolver.js
@@ -176,9 +176,14 @@ export default {
 
   Mutation: {
     requestGroupInfo: async (
-      _, { campuses = [], offset, limit, attributes = [], query, clientIp }, { models, ip, person },
+      _, { groupId, message, communicationPreference }, { models, person },
     ) => {
-      return models.Group.requestGroupInfo();
+      // error for no person
+      if (!person) return null;
+      //error incorrect data
+      if (!groupId || !message || !communicationPreference) return null;
+
+      return models.Group.requestGroupInfo({ groupId, message, communicationPreference }, person);
     },
   },
 

--- a/src/rock/models/groups/schema.js
+++ b/src/rock/models/groups/schema.js
@@ -45,4 +45,11 @@ export default [`
     count: Int
     results: [Group]
   }
+
+  type GroupsMutationResponse implements MutationResponse {
+    error: String
+    success: Boolean!
+    code: Int
+    group: Node
+  }
 `];

--- a/src/rock/models/groups/schema.js
+++ b/src/rock/models/groups/schema.js
@@ -50,6 +50,6 @@ export default [`
     error: String
     success: Boolean!
     code: Int
-    group: Node
   }
+
 `];


### PR DESCRIPTION
# Changes
- added `requestGroupInfo` mutation on groups
- tested mutation, resolver, model methods that I added.

# Notes
- this uses the group's `EntityId`. Not its node id
- returns 400, 401, 404 errors
  - 400 on API errors
  - 404 on group not found
  - 401 on no user