### PR TITLE
Add Campus News

### DIFF
--- a/src/expression-engine/models/content/__tests__/__snapshots__/model.js.snap
+++ b/src/expression-engine/models/content/__tests__/__snapshots__/model.js.snap
@@ -1,0 +1,21 @@
+exports[`findByCampusName should pass correct value for channelTitles 1`] = `
+Object {
+  "entry_date": Object {
+    "$lte": literal {
+      "val": "UNIX_TIMESTAMP(NOW())",
+    },
+  },
+  "expiration_date": Object {
+    "$or": Array [
+      Object {
+        "$eq": 0,
+      },
+      Object {
+        "$gt": literal {
+          "val": "UNIX_TIMESTAMP(NOW())",
+        },
+      },
+    ],
+  },
+}
+`;

--- a/src/expression-engine/models/content/__tests__/__snapshots__/model.js.snap
+++ b/src/expression-engine/models/content/__tests__/__snapshots__/model.js.snap
@@ -1,3 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
 exports[`findByCampusName should pass correct value for channelTitles 1`] = `
 Object {
   "entry_date": Object {

--- a/src/expression-engine/models/content/__tests__/model.js
+++ b/src/expression-engine/models/content/__tests__/model.js
@@ -1,6 +1,18 @@
 
 import { Content } from "../model";
 import { createGlobalId } from "../../../../util/node/model";
+import { ChannelData } from "../tables";
+
+jest.mock("../tables", () => ({
+  ChannelData: {
+    find: jest.fn(),
+  },
+  channelDataSchema: {},
+  channelSchema: {},
+  channelTitleSchema: {},
+  Channels: { Model: "wow" },
+  ChannelTitles: { Model: "lol" },
+}));
 
 jest.mock("../../../../util/node/model");
 
@@ -43,6 +55,104 @@ describe("findByUrlTitle", () => {
     Model.cache.get = jest.fn(() => ({}));
     const res = await Model.findByUrlTitle("articles","harambe");
     expect(res).toEqual(null);
+  });
+
+});
+
+describe("findByCampusName", () => {
+  let Model;
+  beforeEach(() => {
+    Model = new Content();
+    Model.cache.encode = jest.fn(() => "12345");
+    Model.cache.get = jest.fn();
+  });
+  afterEach(() => {
+    Model = null;
+    ChannelData.find.mockReset();
+  });
+
+  it("should exist", () => {
+    expect(Model.findByCampusName).toBeTruthy();
+  });
+
+  it("should call cache lookup", async () => {
+    Model.getFromPublishedIds = jest.fn(() => ["dat Haramboi"]);
+    Model.cache.get = jest.fn(() => Promise.resolve({ entry_id: "1123"}));
+    const res = await Model.findByCampusName({}, "Cincinnati Zoo", true, null);
+    expect(Model.cache.get).toBeCalled();
+    expect(Model.cache.get.mock.calls[0][0]).toEqual("12345");
+    expect(typeof Model.cache.get.mock.calls[0][1]).toEqual("function");
+    expect(Model.cache.get.mock.calls[0][2]).toEqual({ ttl: 3600, cache: false });
+  });
+
+  it("should call find with proper where value for logged out users", async () => {
+    Model.getFromPublishedIds = jest.fn(() => ["dat Haramboi"]);
+    ChannelData.find.mockReturnValueOnce(Promise.resolve([]));
+    //force cache to call second param (find)
+    Model.cache.get.mockImplementationOnce((a, b) => b());
+    const res = await Model.findByCampusName({}, null, true, null);
+    expect(ChannelData.find.mock.calls[0][0].where.field_id_651)
+      .toEqual({ $or: ["", null] });
+  });
+
+  it("should call find with proper where value for logged in users", async () => {
+    Model.getFromPublishedIds = jest.fn(() => ["dat Haramboi"]);
+    ChannelData.find.mockReturnValueOnce(Promise.resolve([]));
+    //force cache to call second param (find)
+    Model.cache.get.mockImplementationOnce((a, b) => b());
+    const res = await Model.findByCampusName({}, "Palace de Harambe", true, null);
+    expect(ChannelData.find.mock.calls[0][0].where.field_id_651)
+      .toEqual({ $or: [{ $like: `%Palace de Harambe`}, "", null ]});
+  });
+
+  it("should pass correct value for globals to find", async () => {
+    Model.getFromPublishedIds = jest.fn(() => ["dat Haramboi"]);
+    ChannelData.find.mockReturnValueOnce(Promise.resolve([]));
+    //force cache to call second param (find)
+    Model.cache.get.mockImplementationOnce((a, b) => b());
+    const res = await Model.findByCampusName({}, "Palace de Harambe", false, null);
+    expect(ChannelData.find.mock.calls[0][0].where.field_id_651)
+      .toEqual({ $like: `%Palace de Harambe`});
+  });
+
+  it("should pass correct value for channel", async () => {
+    Model.getFromPublishedIds = jest.fn(() => ["dat Haramboi"]);
+    ChannelData.find.mockReturnValueOnce(Promise.resolve([]));
+    //force cache to call second param (find)
+    Model.cache.get.mockImplementationOnce((a, b) => b());
+    const res = await Model.findByCampusName({}, "Palace de Harambe", false, null);
+    expect(ChannelData.find.mock.calls[0][0].include[0].where)
+      .toEqual({});
+  });
+
+  it("should pass correct value for channelTitles", async () => {
+    Model.getFromPublishedIds = jest.fn(() => ["dat Haramboi"]);
+    ChannelData.find.mockReturnValueOnce(Promise.resolve([]));
+    //force cache to call second param (find)
+    Model.cache.get.mockImplementationOnce((a, b) => b());
+    const res = await Model.findByCampusName({}, "Palace de Harambe", false, null);
+    expect(ChannelData.find.mock.calls[0][0].include[1].where)
+      .toMatchSnapshot();
+  });
+
+  it("should pass limit", async () => {
+    Model.getFromPublishedIds = jest.fn(() => ["dat Haramboi"]);
+    ChannelData.find.mockReturnValueOnce(Promise.resolve([]));
+    //force cache to call second param (find)
+    Model.cache.get.mockImplementationOnce((a, b) => b());
+    const res = await Model.findByCampusName({ limit: 5, offset: 10 }, "Palace de Harambe", false, null);
+    expect(ChannelData.find.mock.calls[0][0].limit)
+      .toEqual(5);
+  });
+
+  it("should pass offset", async () => {
+    Model.getFromPublishedIds = jest.fn(() => ["dat Haramboi"]);
+    ChannelData.find.mockReturnValueOnce(Promise.resolve([]));
+    //force cache to call second param (find)
+    Model.cache.get.mockImplementationOnce((a, b) => b());
+    const res = await Model.findByCampusName({ limit: 5, offset: 10 }, "Palace de Harambe", false, null);
+    expect(ChannelData.find.mock.calls[0][0].offset)
+      .toEqual(10);
   });
 
 });

--- a/src/expression-engine/models/content/__tests__/resolver.spec.js
+++ b/src/expression-engine/models/content/__tests__/resolver.spec.js
@@ -1190,6 +1190,32 @@ it("`Content` channelName should return channel name", () => {
   expect(channelName).toEqual(mockData.exp_channel.channel_name);
 });
 
+it("`Content` campus should call campus.find", async () => {
+  const { Content } = Resolver;
+  const mockData = { campus: "[1234] [harambe] Clemson" };
+  const mockModels = { models:
+    { Campus: { find: jest.fn(() => Promise.resolve([])) } }
+  };
+
+  const campus = await Content.campus(mockData, null, mockModels);
+  expect(mockModels.models.Campus.find).toHaveBeenCalledWith({ Name: "Clemson" });
+});
+
+it("`Content` campus should return the correct campus", async () => {
+  const { Content } = Resolver;
+  const mockData = { campus: "[1234] [harambe] Clemson" };
+  const mockModels = {
+    models: {
+      Campus: {
+        find: jest.fn(() => Promise.resolve(["cincinnati", "zoo"])),
+      },
+    },
+  };
+
+  const campus = await Content.campus(mockData, null, mockModels);
+  expect(campus).toEqual("cincinnati");
+});
+
 it("`Content` title should return title", () => {
   const { Content } = Resolver;
   const mockData = {
@@ -1402,7 +1428,7 @@ it("`Content` related should call findByTags if tags", () => {
   Content.related(mockData, mockInput, { models });
 });
 
-it("`Contnet` seriesId should return global id", () => {
+it("`Content` seriesId should return global id", () => {
   const { Content } = Resolver;
   const mockData = {
     series_id: "2",

--- a/src/expression-engine/models/content/model.js
+++ b/src/expression-engine/models/content/model.js
@@ -111,13 +111,11 @@ export class Content extends EE {
   }
 
   async getFromPublishedId(id, guid) {
-    console.log(id)
     if (!id) return Promise.resolve();
     const fields = await this.cache.get(`fields:${id}`, () => ChannelData.find({
       where: { entry_id: Number(id) },
       include: [ { model: Channels.model,  include: [ { model: ChannelFields.model } ] } ],
     })
-      .then(this.debug)
       .then(x => flatten(x.map(y => y.exp_channel.exp_channel_field)))
       .then(x => this.createFieldNames(x, true))
     );

--- a/src/expression-engine/models/content/resolver.js
+++ b/src/expression-engine/models/content/resolver.js
@@ -207,6 +207,10 @@ export default {
     id: ({ entry_id }, _, $, { parentType }) => createGlobalId(entry_id, parentType.name),
     channel: ({ channel_id }) => createGlobalId(channel_id, "Channel"),
     channelName: ({ exp_channel }) => exp_channel.channel_name,
+    campus: ({ campus }, _, { models }) => {
+      // campus is playa formatted like "[id] [clemson] Clemson"
+      return campus ? models.Campus.find({ Name: campus.split(" ")[2] }).then(x => x.shift()) : null
+    },
     title: ({ exp_channel_title }) => exp_channel_title.title,
     status: ({ exp_channel_title }) => exp_channel_title.status,
     parent: ({ entry_id }, _, { models }) => models.Content.findByChildId(entry_id),

--- a/src/expression-engine/models/content/schema.js
+++ b/src/expression-engine/models/content/schema.js
@@ -62,6 +62,7 @@ export default [`
     status: String!
     channel: ID!
     channelName: String
+    campus: Campus
     meta: ContentMeta
     content: ContentData
     authors: [String]

--- a/src/rock/models/feeds/__tests__/resolver.spec.js
+++ b/src/rock/models/feeds/__tests__/resolver.spec.js
@@ -62,6 +62,11 @@ const sampleData = {
     title: "hello world",
     campus: { guid: "harambe"},
   },
+  globalNews: {
+    __type: "Content",
+    title: "hello world",
+    campus: null,
+  },
   userCampus: {
     Guid: "something-different",
   },
@@ -230,5 +235,24 @@ describe("Feed Query", () => {
     }, undefined);
 
     expect(results.length).toEqual(1);
+  });
+
+  it("should only show global news to logged out users", async () => {
+    const { Query } = Resolver;
+
+    mockModels.Content.find.mockReturnValueOnce([sampleData.news, sampleData.globalNews]);
+    mockModels.Person.getCampusFromId.mockReturnValueOnce(sampleData.sameCampus);
+
+    const results = await Query.userFeed( //eslint-disable-line
+      null,
+      {
+        filters: ["CONTENT"],
+        options: "{\"content\":{\"channels\":[\"news\",\"series\",\"sermons\",\"stories\",\"studies\"]}}",
+      },
+      { models: mockModels, person: null, person: null },
+    );
+
+    expect(results.length).toEqual(1);
+    expect(results[0].campus).toEqual(null); // global news
   });
 });

--- a/src/rock/models/feeds/__tests__/resolver.spec.js
+++ b/src/rock/models/feeds/__tests__/resolver.spec.js
@@ -172,27 +172,6 @@ describe("Feed Query", () => {
     expect(results[0].__type).toEqual("Content");
   });
 
-  it("should lookup news with news filter", async () => {
-    const { Query } = Resolver;
-
-    mockModels.Content.find.mockReturnValueOnce([sampleData.news]);
-
-    const results = await Query.userFeed( //eslint-disable-line
-      null,
-      { filters: ["NEWS"] },
-      { models: mockModels, person: null, user: { _id: "1234" } },
-    );
-
-    expect(mockModels.Content.find).toHaveBeenCalledWith({
-      channel_name: "news",
-      offset: undefined,
-      limit: undefined,
-      status: undefined,
-    }, undefined);
-    expect(results[0].__type).toEqual("Content");
-    expect(results[0].title).toEqual("hello world");
-  });
-
   it("should call findByCampusName with correct parameters", async () => {
     const { Query } = Resolver;
 

--- a/src/rock/models/feeds/__tests__/resolver.spec.js
+++ b/src/rock/models/feeds/__tests__/resolver.spec.js
@@ -51,7 +51,16 @@ const sampleData = {
       "images": [ { "url": "//drhztd8q3iayu.cloudfront.net/newspring/editorial/articles/newspring.blog.hero.monasterypews.large.jpg", "label": "2:1" } ]
     },
     __type: "Content"
-  }
+  },
+  campus: {
+    id: "12345",
+    guid: "314-1324-5321-5432",
+    name: "harambe",
+  },
+  news: {
+    __type: "Content",
+    title: "hello world",
+  },
 };
 
 describe("Feed Query", () => {
@@ -64,6 +73,9 @@ describe("Feed Query", () => {
     },
     Like: {
       getLikedContent: jest.fn(),
+    },
+    Content: {
+      find: jest.fn(),
     },
     Node: {
 
@@ -137,5 +149,26 @@ describe("Feed Query", () => {
     expect(mockModels.Like.getLikedContent).toHaveBeenCalledWith("1234", {});
     expect(results).toMatchSnapshot();
     expect(results[0].__type).toEqual("Content");
+  });
+
+  it("should lookup news with news filter", async () => {
+    const { Query } = Resolver;
+
+    mockModels.Content.find.mockReturnValueOnce([sampleData.news]);
+
+    const results = await Query.userFeed( //eslint-disable-line
+      null,
+      { filters: ["NEWS"] },
+      { models: mockModels, person: null, user: { _id: "1234" } },
+    );
+
+    expect(mockModels.Content.find).toHaveBeenCalledWith({
+      channel_name: "news",
+      offset: undefined,
+      limit: undefined,
+      status: undefined,
+    }, undefined);
+    expect(results[0].__type).toEqual("Content");
+    expect(results[0].title).toEqual("hello world");
   });
 });

--- a/src/rock/models/feeds/resolver.js
+++ b/src/rock/models/feeds/resolver.js
@@ -4,12 +4,13 @@ import { flatten } from "lodash";
 export default {
 
   Query: {
-    userFeed: (_, { filters, limit, skip, status, cache, options = "{}" }, { models, person, user }) => {
+    userFeed: async (_, { filters, limit, skip, status, cache, options = "{}" }, { models, person, user }) => {
       if (!filters) return null;
 
       const opts = JSON.parse(options);
       const filterQueries = [];
 
+      // Home feed query
       if (filters.includes("CONTENT")) {
         let { channels } = opts.content;
 
@@ -24,9 +25,24 @@ export default {
           })
           .map(flatten);
 
-        filterQueries.push(models.Content.find({
+        //get user's campus to filter news by
+        let userCampus;
+        if (person && flatten(channels).includes("news")) {
+          userCampus = await models.Person.getCampusFromId(person.Id, { cache });
+        }
+
+        // TODO: filter other campuses by lookup query here
+        let content = await models.Content.find({
           channel_name: { $or: channels }, offset: skip, limit, status,
-        }, cache));
+        }, cache);
+
+        // if no campus OR if campus is the same as user, show it
+        content = content.filter((entry) => {
+          return !entry.campus || !userCampus || (userCampus.Guid === entry.campus.guid);
+        });
+
+        // add filtered items to the list
+        filterQueries.push(content);
       }
 
       if (filters.includes("GIVING_DASHBOARD") && person) {

--- a/src/rock/models/feeds/resolver.js
+++ b/src/rock/models/feeds/resolver.js
@@ -1,19 +1,6 @@
 
 import { flatten } from "lodash";
 
-// for filtering news. allows logged out users to see gloabl news only,
-// and logged in users to see global and their campus
-/*
-  userCampus: { Guid: "" }
-  entryCampus: { Guid: "" }
-  => truthy/falsy
-*/
-export const shouldShowEntry = (userCampus, entryCampus) => {
-  return !userCampus
-    ? !entryCampus
-    : Boolean(!entryCampus || (userCampus.Guid === entryCampus.Guid))
-}
-
 export default {
 
   Query: {
@@ -45,30 +32,10 @@ export default {
           ? await models.Person.getCampusFromId(person.Id, { cache })
           : null;
 
-        // TODO: filter other campuses by lookup query here
-        let content = await models.Content.find({
+        let content = await models.Content.findByCampusName({
           channel_name: { $or: channels }, offset: skip, limit, status,
-        }, cache);
+        }, userCampus ? userCampus.Name : null, true);
 
-        // logged out only see global news
-        // logged in only see news that is global, or their campus
-        if (showsNews) {
-          /*
-            XXX since you can't filter on an async filter function, I have to iterate over
-            the array of entries and add a shouldBeShown key than I can use to filter on after
-          */
-          for (let i=0; i < content.length; i++) {
-            const entryCampus = await content[i].campus
-              ? await models.Campus.find({ Name: content[i].campus.split(" ")[2] }).then(x => x.shift())
-              : null;
-            content[i] = { ...content[i], shouldBeShown: shouldShowEntry(userCampus, entryCampus) };
-          }
-
-          content = content.filter( x => x.shouldBeShown );
-
-        }
-
-        // add filtered items to the list
         filterQueries.push(content);
       }
 

--- a/src/rock/models/feeds/resolver.js
+++ b/src/rock/models/feeds/resolver.js
@@ -53,13 +53,6 @@ export default {
         filterQueries.push(models.Like.getLikedContent(user._id, models.Node));
       }
 
-      //for news section in app -- all news
-      if (filters.includes("NEWS")) {
-        filterQueries.push(models.Content.find({
-          channel_name: "news", offset: skip, limit, status,
-        }, cache));
-      }
-
       if (!filterQueries.length) return null;
 
       return Promise.all(filterQueries)

--- a/src/rock/models/feeds/resolver.js
+++ b/src/rock/models/feeds/resolver.js
@@ -36,10 +36,11 @@ export default {
           channel_name: { $or: channels }, offset: skip, limit, status,
         }, cache);
 
-        // if no campus OR if campus is the same as user, show it
-        content = content.filter((entry) => {
-          return !entry.campus || !userCampus || (userCampus.Guid === entry.campus.guid);
-        });
+        // logged out only see global news
+        // logged in only see news that is global, or their campus
+        content = content.filter(
+          (x) => !userCampus ? !x.campus : (!x.campus || (userCampus.Guid === x.campus.guid))
+        );
 
         // add filtered items to the list
         filterQueries.push(content);

--- a/src/rock/models/feeds/resolver.js
+++ b/src/rock/models/feeds/resolver.js
@@ -43,6 +43,13 @@ export default {
         filterQueries.push(models.Like.getLikedContent(user._id, models.Node));
       }
 
+      //for news section in app -- all news
+      if (filters.includes("NEWS")) {
+        filterQueries.push(models.Content.find({
+          channel_name: "news", offset: skip, limit, status,
+        }, cache));
+      }
+
       if (!filterQueries.length) return null;
 
       return Promise.all(filterQueries)


### PR DESCRIPTION
# Changes
- added campus to the content resolver (so we can pull campus with news)
- ~added a `NEWS` filter to the userFeed query~
- filtered news by campus in the userFeed's `CONTENT` filtered section
- Added logged out state for users (only see global news)

# Tests
- added tests for :allthethings:

# Manual Testing (alpha)

**logged out**
_should see global news_

- run below query with `skip: 20`. You should **not** see anderson news item: `Anderson Campus: KidSpring Live Event on 3/15`
- all other things in the list should not have a campus listed
- if you add a `limit` to the query, it should return the proper number

**logged in**
_should see your campus news and global news_

- run the below query with `skip:20`. You **should** see the anderson news item: `Anderson Campus: KidSpring Live Event on 3/15`
- all other things in the list should not have a campus listed
- if you add a `limit` to the query, it should return the proper number

```
{
  userFeed(
    filters:["CONTENT"], skip: 23,
  	options: "{\"content\":{\"channels\":[\"news\"]}}"
  ){
    ... on Content {
    	title
      campus { name }
      meta { date }
    }
  }
}
```