### PR TITLE
Recent likes to pull reverse-chronologically

### DIFF
--- a/src/rock/models/likes/model.js
+++ b/src/rock/models/likes/model.js
@@ -67,7 +67,8 @@ export class Like {
 
     const guid = createGlobalId(`${limit}:${skip}:${userId}`, this.__type);
     const entryIds = await this.cache.get(guid, async () => {
-      const ids = await this.model.distinct("entryId", query);
+      let ids = await this.model.distinct("entryId", query);
+      ids.reverse();
       return safeTrimArray(skip, limit, ids, null);
     });
 

--- a/src/rock/models/likes/model.js
+++ b/src/rock/models/likes/model.js
@@ -68,7 +68,7 @@ export class Like {
     const guid = createGlobalId(`${limit}:${skip}:${userId}`, this.__type);
     const entryIds = await this.cache.get(guid, async () => {
       let ids = await this.model.distinct("entryId", query);
-      ids.reverse();
+      if (ids && Array.isArray(ids)) ids.reverse();
       return safeTrimArray(skip, limit, ids, null);
     });
 


### PR DESCRIPTION
- Recently liked query was pulling likes chronologically, and since the first likes in the DB never change, the recently liked query was pulling incorrect data.

# Changes
- Reverses response array to show reverse-chron
