### PR TITLE
Day filter for groupfinder

### DIFF
--- a/src/rock/models/groups/model.js
+++ b/src/rock/models/groups/model.js
@@ -349,14 +349,6 @@ async findByAttributesAndQuery({ attributes, query, campuses, schedules }, { lim
         av.AttributeId IN (@typeAttributeId, @categoryAttributeId)
         AND g.GroupTypeId = @smallGroupTypeId AND g.IsActive = 1 AND g.IsPublic = 1;
     INSERT INTO #groupTags (GroupId, Tag, TagValue)
-    SELECT g.Id, s.WeeklyDayOfWeek, 2
-    FROM [Group] g
-      JOIN Schedule as s ON s.Id = g.ScheduleId
-    WHERE
-      s.WeeklyDayOfWeek is not null
-      AND s.WeeklyDayOfWeek IN (select Id from @daysOfWeek)
-      AND g.GroupTypeId = @smallGroupTypeId AND g.IsActive = 1 AND g.IsPublic = 1;
-    INSERT INTO #groupTags (GroupId, Tag, TagValue)
     SELECT g.Id, 'Childcare', 1
     FROM [Group] g JOIN AttributeValue av ON av.EntityId = g.Id
     WHERE
@@ -388,7 +380,7 @@ async findByAttributesAndQuery({ attributes, query, campuses, schedules }, { lim
         LEFT JOIN Schedule s ON g.ScheduleId = s.Id
     WHERE
         (LEN(@search) > 0 AND gt.Tag LIKE '%' + @search + '%')
-        OR gt.Tag IN (SELECT Id from @daysOfWeek)
+        ${schedules.length ? "AND s.WeeklyDayOfWeek IN (select Id from @daysOfWeek)" : ""}
         ${attributes.length ? "OR gt.Tag IN (" + attributes.map(x => `'${x}'`).join(", ") + ")" : ""}
         AND g.GroupTypeId = @smallGroupTypeId
         ${campuses.length ? "AND g.CampusId IN (" + campuses.join(", ") + ")" : ""}

--- a/src/rock/models/groups/model.js
+++ b/src/rock/models/groups/model.js
@@ -315,7 +315,7 @@ async findByAttributesAndQuery({ attributes, query, campuses, schedules }, { lim
   let point = `${Number(geo.latitude)}, ${Number(geo.longitude)}, 4326`;
   if (!attributes.length && !query) query = "group"; // most inclusive thing I could think of for blank query
 
-  let q = { attributes, query, geo, campuses };
+  let q = { attributes, query, geo, campuses, schedules };
 
   let insertDays = `INSERT INTO @daysOfWeek(Id) VALUES`
   schedules.map((value, i) => insertDays = `${insertDays}('${value}')${i == schedules.length-1 ? ";" : ","}`);

--- a/src/rock/models/groups/model.js
+++ b/src/rock/models/groups/model.js
@@ -317,7 +317,7 @@ async findByAttributesAndQuery({ attributes, query, campuses, schedules }, { lim
 
   let q = { attributes, query, geo, campuses };
 
-  let insertDays = `INSERT @daysOfWeek(Id) VALUES`
+  let insertDays = `INSERT INTO @daysOfWeek(Id) VALUES`
   schedules.map((value, i) => insertDays = `${insertDays}('${value}')${i == schedules.length-1 ? ";" : ","}`);
 
   // tslint:disable
@@ -380,11 +380,11 @@ async findByAttributesAndQuery({ attributes, query, campuses, schedules }, { lim
         LEFT JOIN Schedule s ON g.ScheduleId = s.Id
     WHERE
         (LEN(@search) > 0 AND gt.Tag LIKE '%' + @search + '%')
-        ${schedules.length ? "AND s.WeeklyDayOfWeek IN (select Id from @daysOfWeek)" : ""}
         ${attributes.length ? "OR gt.Tag IN (" + attributes.map(x => `'${x}'`).join(", ") + ")" : ""}
         AND g.GroupTypeId = @smallGroupTypeId
         ${campuses.length ? "AND g.CampusId IN (" + campuses.join(", ") + ")" : ""}
         AND g.IsActive = 1 AND g.IsPublic = 1
+        ${schedules.length ? "AND s.WeeklyDayOfWeek IN (select Id from @daysOfWeek)" : ""}
     GROUP BY
         gt.GroupId,
         g.Name,

--- a/src/rock/models/groups/queries.js
+++ b/src/rock/models/groups/queries.js
@@ -8,6 +8,7 @@ export default [
     campus: String,
     campuses: [String],
     clientIp: String,
+    schedules: [Int],
   ): GroupSearch`,
 
   // XXX should this take a group type id?

--- a/src/rock/models/groups/resolver.js
+++ b/src/rock/models/groups/resolver.js
@@ -62,7 +62,7 @@ export default {
 
   Query: {
     groups: async (
-      _, { campuses = [], offset, limit, attributes = [], query, clientIp }, { models, ip, person },
+      _, { campuses = [], schedules=[], offset, limit, attributes = [], query, clientIp }, { models, ip, person },
     ) => {
       if (campuses.length) {
         campuses = campuses.map(x => ({ Name: { $like: x } }));
@@ -154,7 +154,7 @@ export default {
       }
 
       return models.Group.findByAttributesAndQuery(
-        { query, attributes, campuses }, { limit, offset, geo },
+        { query, attributes, campuses, schedules }, { limit, offset, geo },
       );
     },
     groupAttributes: (_, $, { models }) => {

--- a/src/rock/models/groups/resolver.js
+++ b/src/rock/models/groups/resolver.js
@@ -70,6 +70,8 @@ export default {
         campuses = campuses.map(x => x.Id);
       }
 
+      if (schedules.length) schedules = schedules.filter((x) => x);
+
       let geo = { latitude: null, longitude: null };
       // XXX move to better location / cleanup
       if (clientIp && ip.match("204.116.47")) {

--- a/src/rock/models/groups/resolver.js
+++ b/src/rock/models/groups/resolver.js
@@ -62,7 +62,7 @@ export default {
 
   Query: {
     groups: async (
-      _, { campuses = [], schedules=[], offset, limit, attributes = [], query, clientIp }, { models, ip, person },
+      _, { campuses = [], schedules = [], offset, limit, attributes = [], query, clientIp }, { models, ip, person },
     ) => {
       if (campuses.length) {
         campuses = campuses.map(x => ({ Name: { $like: x } }));
@@ -70,7 +70,7 @@ export default {
         campuses = campuses.map(x => x.Id);
       }
 
-      if (schedules.length) schedules = schedules.filter((x) => x);
+      if (schedules.length) schedules = schedules.filter((x) => x || x === "0" || x === 0);
 
       let geo = { latitude: null, longitude: null };
       // XXX move to better location / cleanup


### PR DESCRIPTION
- Adds the day filter back to the groups query, only showing results from the days passed to the query.
- If a day isn't passed, it shows results from any day.
- groups with no day scheduled will not be shown in the results if a user is filtering by day.