### PR TITLE
Added platform and version to transactions

### DIFF
--- a/src/rock/models/finances/__tests__/resolver.js
+++ b/src/rock/models/finances/__tests__/resolver.js
@@ -362,6 +362,8 @@ describe("Mutation", () => {
           req: {
             headers: {
               origin: "https://example.com",
+              platform: "Native",
+              version: "over 9000"
             },
           },
         },
@@ -373,6 +375,8 @@ describe("Mutation", () => {
         person: { Id: 1 },
         origin: "https://example.com",
         scheduleId: 1,
+        platform: "Native",
+        version: "over 9000"
       });
     });
     it("passes args and context to the method", async () => {

--- a/src/rock/models/finances/models/Transaction.js
+++ b/src/rock/models/finances/models/Transaction.js
@@ -499,7 +499,7 @@ export default class Transaction extends Rock {
       .catch(e => ({ error: e.message, code: e.code }));
   }
 
-  async completeOrder({ scheduleId, token, person, accountName, origin }) {
+  async completeOrder({ scheduleId, token, person, accountName, origin, platform, version }) {
     const gatewayDetails = await this.loadGatewayDetails("NMI Gateway");
 
     return this.charge(token, gatewayDetails)
@@ -507,7 +507,7 @@ export default class Transaction extends Rock {
         scheduleId, response, person, accountName, origin,
       }, gatewayDetails))
       .then((data) => {
-        this.TransactionJob.add(data);
+        this.TransactionJob.add({...data, platform, version});
         return data;
       })
       .catch(({ message, code }) =>

--- a/src/rock/models/finances/models/TransactionJobs.js
+++ b/src/rock/models/finances/models/TransactionJobs.js
@@ -219,6 +219,8 @@ export default class TransactionJobs extends Rock {
       Person,
       SourceTypeValue,
       Transaction,
+      platform,
+      version,
     } = data;
     if (!Transaction.TransactionCode) return data;
     if (Transaction.Id) return data;
@@ -231,6 +233,17 @@ export default class TransactionJobs extends Rock {
     if (Existing.length) {
       Transaction.Id = Existing[0].Id;
       return data;
+    }
+
+    switch(platform){
+      case "Web":
+        Transaction.SourceTypeValueId = 798; // my.newspring.cc
+        break;
+      case "Native":
+        Transaction.SourceTypeValueId = 884; // native.newspring.cc
+        break;
+      default:
+        break;
     }
 
     if (!Transaction.SourceTypeValueId && SourceTypeValue.Url) {
@@ -249,6 +262,7 @@ export default class TransactionJobs extends Rock {
     });
     if (Batch && Batch.Id) Transaction.BatchId = Batch.Id;
     Transaction.FinancialPaymentDetailId = FinancialPaymentDetail.Id;
+    Transaction.ForeignKey = version ? `v${version}` : null;
 
     Transaction.Id = await TransactionTable.post(Transaction);
 

--- a/src/rock/models/finances/models/TransactionJobs.js
+++ b/src/rock/models/finances/models/TransactionJobs.js
@@ -235,23 +235,8 @@ export default class TransactionJobs extends Rock {
       return data;
     }
 
-    switch(platform){
-      case "Web":
-        Transaction.SourceTypeValueId = 798; // my.newspring.cc
-        break;
-      case "Native":
-        Transaction.SourceTypeValueId = 884; // native.newspring.cc
-        break;
-      default:
-        break;
-    }
-
-    if (!Transaction.SourceTypeValueId && SourceTypeValue.Url) {
-      Transaction.SourceTypeValueId = await DefinedValue.findOne({
-        where: { Value: SourceTypeValue.Url, DefinedTypeId: 12 },
-      })
-        .then(x => x && x.Id || 10);
-    }
+    // 884 source type: (native.ns.cc), default 798: (my.ns.cc)
+    Transaction.SourceTypeValueId = platform === "Native" ? 884 : 798;
 
     Transaction.AuthorizedPersonAliasId = Person.PrimaryAliasId;
     Transaction.CreatedByPersonAliasId = Person.PrimaryAliasId;

--- a/src/rock/models/finances/models/__tests__/Transaction.js
+++ b/src/rock/models/finances/models/__tests__/Transaction.js
@@ -589,7 +589,7 @@ describe("completeOrder", () => {
   it("calls to charge NMI and creates a job", async () => {
     nmi.mockImplementationOnce(() => Promise.resolve({ success: true }));
     formatTransaction.mockClear();
-    formatTransaction.mockReturnValueOnce({});
+    formatTransaction.mockReturnValueOnce({someStuff: "harambe"});
     Local.TransactionJob = {
       add: jest.fn(),
     };
@@ -600,6 +600,8 @@ describe("completeOrder", () => {
       person: { FirstName: "James" },
       accountName: "Visa",
       origin: "http://example.com",
+      version: "over 9000",
+      platform: "Native"
     });
 
     expect(formatTransaction).toBeCalledWith({
@@ -609,7 +611,12 @@ describe("completeOrder", () => {
       origin: "http://example.com",
       response: { success: true },
     }, Local.gateway);
-    expect(Local.TransactionJob.add).toBeCalled();
+
+    expect(Local.TransactionJob.add).toBeCalledWith({
+      platform: "Native",
+      version: "over 9000",
+      someStuff: "harambe",
+    });
   });
 
   it("gracefully handles errors", async () => {

--- a/src/rock/models/finances/resolver.js
+++ b/src/rock/models/finances/resolver.js
@@ -142,6 +142,8 @@ export default {
     ) => {
       if (!token) return null;
       const origin = req.headers.origin;
+      const platform = req.headers.platform;
+      const version = req.headers.version;
 
       // right now scheduleId could also be a meteor userId. This is bad and legacy
       // and should be properally fixed but old builds will still need to support the
@@ -161,7 +163,7 @@ export default {
       }
 
       return models.Transaction
-        .completeOrder({ token, accountName, person, origin, scheduleId })
+        .completeOrder({ token, accountName, person, origin, scheduleId, platform, version })
         .catch(e => ({ error: e.message, code: e.code, success: false }));
     },
     savePayment: async (

--- a/src/rock/models/finances/resolver.js
+++ b/src/rock/models/finances/resolver.js
@@ -142,6 +142,7 @@ export default {
     ) => {
       if (!token) return null;
       const origin = req.headers.origin;
+      // XXX this is temporary until new heighliner supports this for everything
       const platform = req.headers.platform;
       const version = req.headers.version;
 

--- a/src/rock/models/finances/util/logError.js
+++ b/src/rock/models/finances/util/logError.js
@@ -9,7 +9,7 @@ if (process.env.SENTRY) {
 
 const report = ({ data, attemptsMade = 1 }, error) => {
   if (!sentry) {
-    console.error("ERROR", error);
+    if (!process.env.CI) console.error("ERROR", error);
     return;
   }
 


### PR DESCRIPTION
## Changes
- silenced all those thrown errors on CI 🔫 
- added platform and version to resolver and passed to completeOrder
- added platform and version to completeOrder and passed them to `TransactionJob.add`
- added platform and version to `TransactionJob` constructor to save them along with transaction data.
  - added foreign key to saved data with `v5.1.0` style if a version is present, null otherwise