### PR TITLE
Rock Content Queries

### DIFF
--- a/src/rock/index.js
+++ b/src/rock/index.js
@@ -1,4 +1,3 @@
-
 import { connect } from "./mssql";
 
 import { createApplication } from "../util/heighliner";
@@ -8,6 +7,7 @@ import Finances from "./models/finances";
 import Campuses from "./models/campuses";
 import System from "./models/system";
 import Groups from "./models/groups";
+import Content from "./models/content";
 import BinaryFiles from "./models/binary-files";
 import Feeds from "./models/feeds";
 import Likes from "./models/likes";
@@ -18,6 +18,7 @@ export const { mutations, queries, models, resolvers, mocks, schema } = createAp
   Campuses,
   System,
   Groups,
+  Content,
   BinaryFiles,
   Feeds,
   Likes,

--- a/src/rock/models/campuses/model.js
+++ b/src/rock/models/campuses/model.js
@@ -19,12 +19,12 @@ export class Campus extends Rock {
 
   async getFromId(id, globalId) {
     globalId = globalId ? globalId : createGlobalId(`${id}`, this.__type);
-    return this.cache.get(globalId, () => CampusTable.findOne({ where: { Id: id }}));
+    return this.cache.get(globalId, () => CampusTable.findOne({ where: { Id: id } }));
   }
 
   async findByLocationId(id, globalId) {
     globalId = globalId ? globalId : createGlobalId(`${id}`, "Location");
-    return this.cache.get(globalId, () => LocationTable.findOne({ where: { Id: id }}));
+    return this.cache.get(globalId, () => LocationTable.findOne({ where: { Id: id } }));
   }
 
   // async findByPersonId(id) {
@@ -36,19 +36,17 @@ export class Campus extends Rock {
     for (const key in query) {
       if (!query[key]) delete query[key];
     }
-    return this.cache.get(this.cache.encode(query), () => CampusTable.find({
-        where: query,
-        attributes: ["Id"],
-      })
-    ,)
-      .then(this.debug)
+    return this.cache
+      .get(this.cache.encode(query), () =>
+        CampusTable.find({
+          where: query,
+          attributes: ["Id"],
+        }),
+      )
       .then(this.getFromIds.bind(this))
-      .then((x) => x.filter(y => y.Name !== "Central"))
-      ;
-
+      .then(x => x.filter(y => y.Name !== "Central"))
+      .then(this.debug);
   }
-
-
 }
 
 export default {

--- a/src/rock/models/content/index.js
+++ b/src/rock/models/content/index.js
@@ -1,0 +1,11 @@
+import schema from "./schema";
+import resolvers from "./resolver";
+import models from "./model";
+import queries from "./queries";
+
+export default {
+  schema,
+  resolvers,
+  models,
+  queries,
+};

--- a/src/rock/models/content/model.js
+++ b/src/rock/models/content/model.js
@@ -81,8 +81,8 @@ export class RockContent extends Rock {
           item.__type = this.__type;
           return item;
         }),
-      )
-      .then(this.debug);
+      );
+    // .then(this.debug);
   }
 }
 export default {

--- a/src/rock/models/content/model.js
+++ b/src/rock/models/content/model.js
@@ -1,8 +1,9 @@
-import { merge } from "lodash";
+import { merge, isNil, pick, flatten, find, uniq, sampleSize } from "lodash";
 import { defaultCache } from "../../../util/cache";
 import { createGlobalId } from "../../../util";
 
 import { ContentChannel, ContentChannelItem } from "./tables";
+import { AttributeValue, Attribute } from "../system/tables";
 
 import { Rock } from "../system";
 
@@ -14,13 +15,76 @@ export class RockContent extends Rock {
     this.cache = cache;
   }
 
-  find(channel) {
-    return {
-      Channel: channel,
-    };
+  async getAttributeFromId(key, id, globalId) {
+    globalId = globalId ? globalId : createGlobalId(`Content:${id}:${key}`, this.__type);
+    return this.cache
+      .get(globalId, () =>
+        AttributeValue.find({
+          attributes: ["Value"],
+          include: [
+            {
+              model: Attribute.model,
+              attributes: ["Name"],
+              where: {
+                EntityTypeQualifierColumn: { $or: ["ContentChannelTypeId", "ContentChannelId"] },
+                EntityTypeQualifierValue: { $or: [3, 5] },
+                Key: key,
+              },
+            },
+          ],
+          where: {
+            EntityId: id,
+          },
+        }),
+      )
+      .then(x => x.map(y => y.Value));
+  }
+
+  /**
+      SELECT av.[Value],a.[Name]
+      FROM AttributeValue av
+      INNER JOIN Attribute a
+      ON av.AttributeId = a.Id
+      WHERE
+      AND (
+      (
+          a.EntityTypeQualifierColumn  = 'ContentChannelTypeId' AND
+          a.EntityTypeQualifierValue = 3
+      )
+      OR
+      (
+          a.EntityTypeQualifierColumn = 'ContentChannelId' AND
+          a.EntityTypeQualifierValue = 5
+      )
+      )
+
+    --AND
+    --a.[Key] = 'Image' AND
+    --av.EntityId = 1586
+    **/
+
+  async find(query) {
+    const { limit, offset, channel } = query; // true options
+
+    return await this.cache
+      .get(this.cache.encode(query, this.__type), () =>
+        ContentChannelItem.find({
+          order: [["StartDateTime", "desc"]],
+          include: [{ model: ContentChannel.model, where: { Name: `${channel}` } }],
+        }),
+      )
+      .then(x => x.slice(offset, limit + offset))
+      .then(flatten)
+      .then(x =>
+        x.filter(y => !isNil(y)).map((z) => {
+          const item = z;
+          item.__type = this.__type;
+          return item;
+        }),
+      )
+      .then(this.debug);
   }
 }
-
 export default {
   RockContent,
 };

--- a/src/rock/models/content/model.js
+++ b/src/rock/models/content/model.js
@@ -1,0 +1,26 @@
+import { merge } from "lodash";
+import { defaultCache } from "../../../util/cache";
+import { createGlobalId } from "../../../util";
+
+import { ContentChannel, ContentChannelItem } from "./tables";
+
+import { Rock } from "../system";
+
+export class RockContent extends Rock {
+  __type = "RockContent";
+
+  constructor({ cache } = { cache: defaultCache }) {
+    super();
+    this.cache = cache;
+  }
+
+  find(channel) {
+    return {
+      Channel: channel,
+    };
+  }
+}
+
+export default {
+  RockContent,
+};

--- a/src/rock/models/content/queries.js
+++ b/src/rock/models/content/queries.js
@@ -2,6 +2,6 @@ export default [
   `rockContent(
     channel: String!,
     limit: Int = 20,
-    skip: Int = 0,
+    offset: Int = 0,
   ): [RockContent]`,
 ];

--- a/src/rock/models/content/queries.js
+++ b/src/rock/models/content/queries.js
@@ -1,0 +1,7 @@
+export default [
+  `rockContent(
+    channel: String!,
+    limit: Int = 20,
+    skip: Int = 0,
+  ): [RockContent]`,
+];

--- a/src/rock/models/content/resolver.js
+++ b/src/rock/models/content/resolver.js
@@ -1,0 +1,34 @@
+// import { flatten, difference } from "lodash";
+// import sortBy from "lodash/sortBy";
+// import StripTags from "striptags";
+// import Truncate from "truncate";
+// import { addResizings } from "./images";
+import { createGlobalId } from "../../../util";
+
+export default {
+  Query: {
+    rockContent(_, { channel, limit, skip, status, cache }, { models }) {
+      const RContent = models.RockContent.find(channel);
+      console.log(RContent);
+      return RContent;
+      // return models.RockContent.find(
+      //   {
+      //     channel_name: channel,
+      //     offset: skip,
+      //     limit,
+      //   },
+      //   cache,
+      // );
+    },
+  },
+  RockContent: {
+    id: ({ Id }, _, $, { parentType }) => createGlobalId(Id, parentType.name),
+    channel: ({ Channel }) => Channel,
+  },
+  // RockContentData: {
+  //   body: () => "body",
+  //   description: () => "description",
+  //   ooyalaId: () => "jdafsd",
+  //   images: () => "hello images",
+  // },
+};

--- a/src/rock/models/content/resolver.js
+++ b/src/rock/models/content/resolver.js
@@ -24,6 +24,9 @@ export default {
     typeId: ({ ContentChannelTypeId }) => ContentChannelTypeId,
     description: ({ Description }) => Description,
   },
+  RockMeta: {
+    date: ({ StartDateTime }) => StartDateTime,
+  },
   RockContent: {
     id: ({ Id }, _, $, { parentType }) => createGlobalId(Id, parentType.name),
     entityId: ({ Id }) => Id,
@@ -35,5 +38,7 @@ export default {
     ooyalaId: ({ Id }, _, { models }) => models.RockContent.getAttributeFromId("Video ID", Id),
     audioUrl: ({ Id }, _, { models }) => models.RockContent.getAttributeFromId("Audio URL", Id),
     channel: ({ ContentChannel }) => ContentChannel,
+    channelName: ({ ContentChannel }) => ContentChannel.Name,
+    meta: data => data,
   },
 };

--- a/src/rock/models/content/resolver.js
+++ b/src/rock/models/content/resolver.js
@@ -7,28 +7,33 @@ import { createGlobalId } from "../../../util";
 
 export default {
   Query: {
-    rockContent(_, { channel, limit, skip, status, cache }, { models }) {
-      const RContent = models.RockContent.find(channel);
-      console.log(RContent);
-      return RContent;
-      // return models.RockContent.find(
-      //   {
-      //     channel_name: channel,
-      //     offset: skip,
-      //     limit,
-      //   },
-      //   cache,
-      // );
-    },
+    rockContent: (_, { channel, limit, offset, cache }, { models }) =>
+      models.RockContent.find(
+        {
+          channel,
+          offset,
+          limit,
+        },
+        cache,
+      ),
+  },
+  RockContentChannel: {
+    id: ({ Id }, _, $, { parentType }) => createGlobalId(Id, parentType.name),
+    name: ({ Name }) => Name,
+    url: ({ ChannelUrl }) => ChannelUrl,
+    typeId: ({ ContentChannelTypeId }) => ContentChannelTypeId,
+    description: ({ Description }) => Description,
   },
   RockContent: {
     id: ({ Id }, _, $, { parentType }) => createGlobalId(Id, parentType.name),
-    channel: ({ Channel }) => Channel,
+    entityId: ({ Id }) => Id,
+    content: ({ Content }) => Content,
+    title: ({ Title }) => Title,
+    entrydate: ({ StartDateTime }) => StartDateTime,
+    image: ({ Id }, _, { models }) => models.RockContent.getAttributeFromId("Image", Id),
+    summary: ({ Id }, _, { models }) => models.RockContent.getAttributeFromId("Summary", Id),
+    ooyalaId: ({ Id }, _, { models }) => models.RockContent.getAttributeFromId("Video ID", Id),
+    audioUrl: ({ Id }, _, { models }) => models.RockContent.getAttributeFromId("Audio URL", Id),
+    channel: ({ ContentChannel }) => ContentChannel,
   },
-  // RockContentData: {
-  //   body: () => "body",
-  //   description: () => "description",
-  //   ooyalaId: () => "jdafsd",
-  //   images: () => "hello images",
-  // },
 };

--- a/src/rock/models/content/schema.js
+++ b/src/rock/models/content/schema.js
@@ -1,10 +1,24 @@
 export default [
   `
+  type RockContentChannel {
+    id: ID!
+    name: String
+    url: String
+    typeId: Int
+    description: String
+  }
 
   type RockContent implements Node{
     id: ID!
-    title: String!
-    channel: String!
+    entityId: Int
+    content: String
+    title: String
+    entrydate: String
+    image: String
+    summary: String
+    ooyalaId: String
+    audioUrl: String
+    channel: RockContentChannel
   }
 `,
 ];

--- a/src/rock/models/content/schema.js
+++ b/src/rock/models/content/schema.js
@@ -8,6 +8,10 @@ export default [
     description: String
   }
 
+  type RockMeta {
+    date: String
+  }
+
   type RockContent implements Node{
     id: ID!
     entityId: Int
@@ -19,6 +23,8 @@ export default [
     ooyalaId: String
     audioUrl: String
     channel: RockContentChannel
+    channelName: String
+    meta: RockMeta
   }
 `,
 ];

--- a/src/rock/models/content/schema.js
+++ b/src/rock/models/content/schema.js
@@ -1,0 +1,10 @@
+export default [
+  `
+
+  type RockContent implements Node{
+    id: ID!
+    title: String!
+    channel: String!
+  }
+`,
+];

--- a/src/rock/models/content/tables.js
+++ b/src/rock/models/content/tables.js
@@ -36,15 +36,33 @@ export { ContentChannel, contentChannelSchema, ContentChannelItem, contentChanne
 export function connect() {
   ContentChannel = new MSSQLConnector("ContentChannel", contentChannelSchema);
   ContentChannelItem = new MSSQLConnector("ContentChannelItem", contentChannelItemSchema);
+
+  return {
+    ContentChannel,
+    ContentChannelItem,
+  };
 }
 
 export function bind({ ContentChannel, ContentChannelItem, AttributeValue }) {
+  ContentChannelItem.model.belongsTo(ContentChannel.model, {
+    foreignKey: "ContentChannelId",
+    targetKey: "Id",
+  });
+
   ContentChannel.model.hasMany(ContentChannelItem.model, {
     foreignKey: "ContentChannelId",
     targetKey: "Id",
   });
 
-  ContentChannelItem.model.hasMany(AttributeValue.model, { foreignKey: "EntityId" });
+  AttributeValue.model.belongsTo(ContentChannelItem.model, {
+    foreignKey: "EntityId",
+    targetKey: "ContentChannelId",
+  });
+
+  ContentChannelItem.model.hasMany(AttributeValue.model, {
+    foreignKey: "EntityId",
+    targetKey: "Id",
+  });
 }
 
 export default {

--- a/src/rock/models/content/tables.js
+++ b/src/rock/models/content/tables.js
@@ -1,0 +1,53 @@
+import { INTEGER, STRING } from "sequelize";
+
+import { MSSQLConnector } from "../../mssql";
+
+const contentChannelSchema = {
+  Id: { type: INTEGER, primaryKey: true },
+  Name: { type: STRING },
+  ChannelUrl: { type: STRING },
+  ContentChannelTypeId: { type: INTEGER },
+  ContentControlType: { type: STRING },
+  Description: { type: STRING },
+  ItemsManuallyOrdered: { type: STRING },
+  ItemUrl: { type: STRING },
+};
+
+const contentChannelItemSchema = {
+  Id: { type: INTEGER, primaryKey: true },
+  ApprovedByPersonAliasId: { type: STRING },
+  ApprovedDateTime: { type: STRING },
+  Content: { type: STRING },
+  ContentChannelId: { type: INTEGER },
+  ContentChannelTypeId: { type: INTEGER },
+  ExpireDateTime: { type: STRING },
+  Permalink: { type: STRING },
+  Priority: { type: INTEGER },
+  StartDateTime: { type: STRING },
+  Status: { type: STRING },
+  Title: { type: STRING },
+};
+
+let ContentChannel;
+let ContentChannelItem;
+
+export { ContentChannel, contentChannelSchema, ContentChannelItem, contentChannelItemSchema };
+
+export function connect() {
+  ContentChannel = new MSSQLConnector("ContentChannel", contentChannelSchema);
+  ContentChannelItem = new MSSQLConnector("ContentChannelItem", contentChannelItemSchema);
+}
+
+export function bind({ ContentChannel, ContentChannelItem, AttributeValue }) {
+  ContentChannel.model.hasMany(ContentChannelItem.model, {
+    foreignKey: "ContentChannelId",
+    targetKey: "Id",
+  });
+
+  ContentChannelItem.model.hasMany(AttributeValue.model, { foreignKey: "EntityId" });
+}
+
+export default {
+  connect,
+  bind,
+};

--- a/src/rock/models/feeds/queries.js
+++ b/src/rock/models/feeds/queries.js
@@ -1,7 +1,4 @@
-
-
 export default [
-
   `userFeed(
     filters: [String]!
     options: String = "{}"
@@ -10,5 +7,4 @@ export default [
     status: String = "open",
     cache: Boolean = true
   ): [Node]`,
-
 ];

--- a/src/rock/models/feeds/resolver.js
+++ b/src/rock/models/feeds/resolver.js
@@ -30,11 +30,10 @@ export default {
         const showsNews = flatten(channels).includes("news");
 
         // get user's campus to filter news by
-        let userCampus = person && showsNews
-          ? await models.Person.getCampusFromId(person.Id, { cache })
-          : null;
+        const userCampus =
+          person && showsNews ? await models.Person.getCampusFromId(person.Id, { cache }) : null;
 
-        let eeContent = await models.Content.findByCampusName(
+        const EEContent = await models.Content.findByCampusName(
           {
             channel_name: { $or: channels },
             offset: skip,
@@ -45,13 +44,18 @@ export default {
           true,
         );
 
-        let RockContent = await models.RockContent.findByCampusId(
+        const RKContent = await models.RockContent.find(
           {
-            //what do we need to search with?
-          }
-        )
+            channel: "All Staff News",
+            offset: skip,
+            limit,
+          },
+          cache,
+        );
 
-        filterQueries.push(EEcontent);
+        // console.log("RKCONTENT: ", RKContent);
+
+        filterQueries.push(EEContent, RKContent);
       }
 
       if (filters.includes("GIVING_DASHBOARD") && person) {

--- a/src/rock/models/feeds/resolver.js
+++ b/src/rock/models/feeds/resolver.js
@@ -53,9 +53,7 @@ export default {
           cache,
         );
 
-        // console.log("RKCONTENT: ", RKContent);
-
-        filterQueries.push(EEContent, RKContent);
+        filterQueries.push(RKContent);
       }
 
       if (filters.includes("GIVING_DASHBOARD") && person) {
@@ -84,7 +82,27 @@ export default {
 
       if (!filterQueries.length) return null;
 
-      return Promise.all(filterQueries).then(flatten).then(x => x.filter(y => Boolean(y)));
+      return Promise.all(filterQueries).then(flatten).then(x => x.filter(y => Boolean(y))).then(z =>
+        z.sort((a, b) => {
+          let aDate;
+          let bDate;
+          if (a.__type === "Content") {
+            aDate = `${a.exp_channel_title.year}-${a.exp_channel_title.month}-${a.exp_channel_title
+              .day}`;
+          } else {
+            aDate = a.StartDateTime.slice(0, 10);
+          }
+          if (b.__type === "Content") {
+            bDate = `${b.exp_channel_title.year}-${b.exp_channel_title.month}-${b.exp_channel_title
+              .day}`;
+          } else {
+            bDate = b.StartDateTime.slice(0, 10);
+          }
+          aDate = new Date(aDate);
+          bDate = new Date(bDate);
+          return aDate > bDate ? -1 : aDate < bDate ? 1 : 0;
+        }),
+      );
     },
   },
 };

--- a/src/rock/models/feeds/resolver.js
+++ b/src/rock/models/feeds/resolver.js
@@ -34,7 +34,7 @@ export default {
           ? await models.Person.getCampusFromId(person.Id, { cache })
           : null;
 
-        let content = await models.Content.findByCampusName(
+        let eeContent = await models.Content.findByCampusName(
           {
             channel_name: { $or: channels },
             offset: skip,
@@ -45,7 +45,13 @@ export default {
           true,
         );
 
-        filterQueries.push(content);
+        let RockContent = await models.RockContent.findByCampusId(
+          {
+            //what do we need to search with?
+          }
+        )
+
+        filterQueries.push(EEcontent);
       }
 
       if (filters.includes("GIVING_DASHBOARD") && person) {

--- a/src/rock/models/index.js
+++ b/src/rock/models/index.js
@@ -5,6 +5,7 @@ import finances from "./finances/tables";
 import system from "./system/tables";
 import campuses from "./campuses/tables";
 import groups from "./groups/tables";
+import content from "./content/tables";
 import binaryFiles from "./binary-files/tables";
 
 const tables = {
@@ -13,6 +14,7 @@ const tables = {
   system,
   campuses,
   groups,
+  content,
   binaryFiles,
 };
 
@@ -22,7 +24,9 @@ export function createTables() {
   for (const table in tables) {
     try {
       createdTables = merge(createdTables, tables[table].connect());
-    } catch (e) { console.error(e); }
+    } catch (e) {
+      console.error(e);
+    }
   }
 
   for (const table in tables) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4636,11 +4636,7 @@ rechoir@^0.6.2:
   dependencies:
     resolve "^1.1.6"
 
-redis-commands@^1.2.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/redis-commands/-/redis-commands-1.3.0.tgz#4307d8094aee1315829ab6729b37b99f62365d63"
-
-"redis-commands@github:newspring/redis-commands":
+redis-commands@^1.2.0, "redis-commands@github:newspring/redis-commands":
   version "1.2.0"
   resolved "https://codeload.github.com/newspring/redis-commands/tar.gz/2f31431fbc773e0e80ffff3c53131ceb38d4e50b"
 


### PR DESCRIPTION
This PR is for a PoC for querying content data from rock.

The basic query looks like:
```graphql
query RockContent{
  rockContent(channel:"All Staff News", limit:10, offset:0){
    entityId
    entrydate
    title
    content
    image
    summary
    ooyalaId
    audioUrl
    channel {
      id
      name
      description
    }
  }
}
```

This PR also includes updates to the `userfeed` query:

```graphql
query HomeFeed($filters: [String]!, $options: String!, $limit: Int!, $skip: Int!, $cache: Boolean!) {
  feed: userFeed(filters: $filters, options: $options, limit: $limit, skip: $skip, cache: $cache) {
    __typename
    ... on RockContent{
      ...RockContentForFeed
    }
    ... on Content {
      ...ContentForFeed
      parent {
        ...ContentForFeed
      }
    }
  }
}

fragment RockContentForFeed on RockContent{
  __typename
  id
  rockTitle: title
  entrydate
}

fragment ContentForFeed on Content {
  entryId: id
  title
  channelName
  status
  meta {
    siteId
    date
    channelId
  }
  content {
    images(sizes: ["large"]) {
      fileName
      fileType
      fileLabel
      url
    }
    isLight
    colors {
      id
      value
      description
    }
  }
}
```

Couple of notes:
1. Most of the content data from the channel we are using doesn't have much data, most of the returned data besides `title`,`name`,`content`,`entrydate` is going to be empty. 
2. There is no way to specify a content channel in the filter to pull rock data yet. Its hard coded to only pull `All Staff News`
3. The data returned from userfeed isn't ordered by any datetime yet. This is just a proof of concept to see if/how it would be possible to pull rock data.

See you guys in a week!

