### PR TITLE
updated rock impersonation parameter api call

### DIFF
--- a/src/rock/models/people/__tests__/model.js
+++ b/src/rock/models/people/__tests__/model.js
@@ -2,7 +2,7 @@ import { PhoneNumber, Person, PersonalDevice } from "../model";
 import {
   PhoneNumber as PhoneNumberTable,
   Person as PersonTable,
-  PersonalDevice as PersonalDeviceTable
+  PersonalDevice as PersonalDeviceTable,
 } from "../tables";
 
 import { AttributeValue, Attribute } from "../../system/tables";
@@ -10,7 +10,7 @@ import { AttributeValue, Attribute } from "../../system/tables";
 import {
   Group,
   GroupMember,
-  GroupLocation
+  GroupLocation,
   // GroupTypeRole,
   // GroupType,
 } from "../../groups/tables";
@@ -20,45 +20,50 @@ jest.mock("../tables", () => ({
     post: jest.fn(),
     findOne: jest.fn(),
     cache: {
-      del: jest.fn(() => {})
-    }
+      del: jest.fn(() => {}),
+    },
   },
   Person: {
-    fetch: jest.fn()
+    fetch: jest.fn(),
   },
   PersonalDevice: {
     post: jest.fn(),
     findOne: jest.fn(),
     find: jest.fn(),
     cache: {
-      del: jest.fn(() => {})
-    }
-  }
+      del: jest.fn(() => {}),
+    },
+  },
 }));
 
 jest.mock("../../groups/tables", () => ({
   Group: {
-    find: jest.fn()
+    find: jest.fn(),
   },
   GroupMember: {
-    model: "GroupMember"
-  }
+    model: "GroupMember",
+  },
 }));
 
 jest.mock("../../system/tables", () => ({
   Attribute: {
-    model: "AttributeModel"
+    model: "AttributeModel",
   },
   AttributeValue: {
-    model: "AttributeValueModel"
-  }
+    model: "AttributeValueModel",
+  },
 }));
 
 jest.mock("node-uuid", () => ({
-  v4: () => "guid"
+  v4: () => "guid",
 }));
 
 const mockArgs = { phoneNumber: "(555) 555-5555" };
+const personArgs = {
+  expireDateTime: "2037-09-03T17:56:26-04:00",
+  usageLimit: 1,
+  pageId: 100,
+};
 
 describe("setPhoneNumber", () => {
   let phoneNumberModel;
@@ -89,7 +94,7 @@ describe("setPhoneNumber", () => {
 
     await setPhoneNumber(mockArgs, { Id: 9999999999 });
     expect(PhoneNumberTable.findOne).toHaveBeenCalledWith({
-      where: { Number: "5555555555", PersonId: 9999999999 }
+      where: { Number: "5555555555", PersonId: 9999999999 },
     });
   });
 
@@ -105,7 +110,7 @@ describe("setPhoneNumber", () => {
     const { setPhoneNumber } = phoneNumberModel;
     PhoneNumberTable.post.mockReturnValueOnce({
       status: 404,
-      statusText: "BAD BAD BAD"
+      statusText: "BAD BAD BAD",
     });
 
     const result = await setPhoneNumber(mockArgs, { Id: 9999999999 });
@@ -125,7 +130,7 @@ describe("Person", () => {
   let personModel;
   let personalDeviceModel;
   const mockedCache = {
-    get: jest.fn((id, lookup) => Promise.resolve().then(lookup))
+    get: jest.fn((id, lookup) => Promise.resolve().then(lookup)),
   };
 
   beforeEach(() => {
@@ -143,30 +148,30 @@ describe("Person", () => {
         {
           model: GroupMember.model,
           where: { PersonId: "12" },
-          attributes: []
+          attributes: [],
         },
         {
           model: AttributeValue.model,
-          include: [{ model: Attribute.model }]
-        }
-      ]
+          include: [{ model: Attribute.model }],
+        },
+      ],
     });
   });
 
   it("gets person groups from cache lookup", async () => {
     await personModel.getGroups(12, 34);
     expect(mockedCache.get.mock.calls[0][0]).toEqual(
-      "12:GroupMemberId:34:GroupTypes"
+      "12:GroupMemberId:34:GroupTypes",
     );
     expect(typeof mockedCache.get.mock.calls[0][1]).toEqual("function");
   });
 
   describe("getIP", () => {
     it("should lookup on getIP", async () => {
-      await personModel.getIP(123);
+      await personModel.getIP(123, personArgs);
       expect(PersonTable.fetch).toHaveBeenCalledWith(
         "GET",
-        "GetSearchDetails/123"
+        "GetImpersonationParameter/?personId=123&expireDateTime=09%2F03%2F2037&usageLimit=1&pageId=100",
       );
     });
   });
@@ -178,7 +183,7 @@ describe("Person", () => {
       expect(res).toEqual({
         code: 400,
         success: false,
-        error: "Insufficient information"
+        error: "Insufficient information",
       });
     });
 
@@ -188,7 +193,7 @@ describe("Person", () => {
       expect(res).toEqual({
         code: 400,
         success: false,
-        error: "Insufficient information"
+        error: "Insufficient information",
       });
     });
 
@@ -198,14 +203,14 @@ describe("Person", () => {
       expect(res).toEqual({
         code: 400,
         success: false,
-        error: "Insufficient information"
+        error: "Insufficient information",
       });
     });
 
     it("posts with correct info", async () => {
       const { saveId } = personalDeviceModel;
       const res = await saveId("123456", "chrome", {
-        PrimaryAliasId: "harambe"
+        PrimaryAliasId: "harambe",
       });
       expect(PersonalDeviceTable.post).toBeCalledWith({
         PersonAliasId: "harambe",
@@ -213,7 +218,7 @@ describe("Person", () => {
         PersonalDeviceTypeId: 671, // `mobile` device type
         NotificationsEnabled: 1,
         ForeignKey: "chrome",
-        Guid: "guid"
+        Guid: "guid",
       });
       expect(res).toEqual({ code: 200, success: true });
     });
@@ -221,7 +226,7 @@ describe("Person", () => {
     it("returns with 200 if post doesn't fail", async () => {
       const { saveId } = personalDeviceModel;
       const res = await saveId("123456", "chrome", {
-        PrimaryAliasId: "harambe"
+        PrimaryAliasId: "harambe",
       });
       expect(res).toEqual({ code: 200, success: true });
     });
@@ -230,10 +235,10 @@ describe("Person", () => {
       const { saveId } = personalDeviceModel;
       PersonalDeviceTable.post.mockReturnValueOnce({
         status: 9999,
-        statusText: "bruh no"
+        statusText: "bruh no",
       });
       const res = await saveId("123456", "chrome", {
-        PrimaryAliasId: "harambe"
+        PrimaryAliasId: "harambe",
       });
       expect(res).toEqual({ code: 9999, success: false, error: "bruh no" });
     });

--- a/src/rock/models/people/__tests__/resolver.spec.js
+++ b/src/rock/models/people/__tests__/resolver.spec.js
@@ -12,15 +12,15 @@ const sampleData = {
     BirthDay: "17",
     BirthYear: "1984",
     BirthMonth: "10",
-    Email: "email@example.com"
+    Email: "email@example.com",
   },
   phone: {
     CountryCode: "1",
     Description: "Home",
     IsMessagingEnabled: "true",
     Number: "8648675309",
-    PersonId: "12345-ABCDE"
-  }
+    PersonId: "12345-ABCDE",
+  },
 };
 
 describe("Person Tests", () => {
@@ -63,8 +63,8 @@ describe("Person Tests", () => {
         getFromId(id) {
           expect(id).toEqual(samplePhotoId);
           return Promise.resolve({ Path: placeHolderPhoto });
-        }
-      }
+        },
+      },
     };
 
     Person.photo({ PhotoId: samplePhotoId }, null, { models });
@@ -82,7 +82,7 @@ describe("Person Tests", () => {
     expect(models.Rock.getAttributesFromEntity).toHaveBeenCalledWith(
       123,
       "ThugLyfe",
-      15
+      15,
     );
   });
 
@@ -105,7 +105,7 @@ describe("PhoneNumber Mutations", () => {
     expect(result).toEqual({
       code: 401,
       error: "Must be logged in to make this request",
-      success: false
+      success: false,
     });
   });
 
@@ -115,26 +115,32 @@ describe("PhoneNumber Mutations", () => {
     await setPhoneNumber(
       null,
       {
-        phoneNumber: "(555) 555-5555"
+        phoneNumber: "(555) 555-5555",
       },
-      { models, person: "person" }
+      { models, person: "person" },
     );
     expect(models.PhoneNumber.setPhoneNumber).toHaveBeenCalledWith(
       {
-        phoneNumber: "(555) 555-5555"
+        phoneNumber: "(555) 555-5555",
       },
-      "person"
+      "person",
     );
   });
 
   it("should have an impersonation parameter", async () => {
     const models = { Person: { getIP: jest.fn() } };
     const person = { Id: 1234 };
+    const ipArgs = {
+      expireDateTime: "2037-09-03T17:56:26-04:00",
+      usageLimit: 1,
+      pageId: 100,
+    };
+
     const { impersonationParameter } = Resolver.Person;
 
-    await impersonationParameter(person, null, { models, person });
+    await impersonationParameter(person, ipArgs, { models, person });
 
-    expect(models.Person.getIP).toHaveBeenCalledWith(1234);
+    expect(models.Person.getIP).toHaveBeenCalledWith(1234, ipArgs);
   });
 
   it("should not return an ip if person not logged in", async () => {
@@ -155,7 +161,7 @@ describe("DeviceRegistration Mutation", () => {
     expect(result).toEqual({
       code: 401,
       error: "Must be logged in to make this request",
-      success: false
+      success: false,
     });
   });
 
@@ -166,14 +172,14 @@ describe("DeviceRegistration Mutation", () => {
       null,
       {
         registrationId: "harambe",
-        uuid: "chrome"
+        uuid: "chrome",
       },
-      { models, person: "person" }
+      { models, person: "person" },
     );
     expect(models.PersonalDevice.saveId).toHaveBeenCalledWith(
       "harambe",
       "chrome",
-      "person"
+      "person",
     );
   });
 });

--- a/src/rock/models/people/resolver.js
+++ b/src/rock/models/people/resolver.js
@@ -4,7 +4,7 @@ import { createGlobalId } from "../../../util";
 const MutationReponseResolver = {
   error: ({ error }) => error,
   success: ({ success, error }) => success || !error,
-  code: ({ code }) => code
+  code: ({ code }) => code,
 };
 // models.Rock.getAttributeValueFromMatrix('SiteVersion', 'Sites', 10, 'Version')
 
@@ -20,14 +20,14 @@ export default {
       if (cache && person) return person;
       if (user && user.services && user.services.rock) {
         return models.Person.getFromAliasId(user.services.rock.PrimaryAliasId, {
-          cache
+          cache,
         });
       }
     },
     currentFamily: (_, args, { models, person }) => {
       if (!person) return null;
       return models.Person.getFamilyFromId(person.Id);
-    }
+    },
   },
 
   Mutation: {
@@ -36,7 +36,7 @@ export default {
         return {
           code: 401,
           success: false,
-          error: "Must be logged in to make this request"
+          error: "Must be logged in to make this request",
         };
       }
       return models.PhoneNumber.setPhoneNumber({ phoneNumber }, person);
@@ -44,14 +44,15 @@ export default {
     saveDeviceRegistrationId: (
       _,
       { registrationId, uuid },
-      { models, person }
+      { models, person },
     ) => {
-      if (!person)
+      if (!person) {
         return {
           code: 401,
           success: false,
-          error: "Must be logged in to make this request"
+          error: "Must be logged in to make this request",
         };
+      }
       return models.PersonalDevice.saveId(registrationId, uuid, person);
     },
     setPersonAttribute: (_, { value, key }, { models, person, ...rest }) => {
@@ -59,15 +60,15 @@ export default {
         return {
           code: 401,
           success: false,
-          error: "Must be logged in to make this request"
+          error: "Must be logged in to make this request",
         };
       }
       return models.Person.setPersonAttribute({ key, value }, person, {
         models,
         person,
-        ...rest
+        ...rest,
       });
-    }
+    },
   },
 
   Person: {
@@ -77,14 +78,14 @@ export default {
     firstName: ({ FirstName }) => FirstName,
     lastName: ({ LastName }) => LastName,
     nickName: ({ NickName }) => NickName,
-    impersonationParameter: ({ Id }, _, { models, person }) => {
+    impersonationParameter: ({ Id }, args, { models, person }) => {
       if (!person || !person.Id) return null;
-      return models.Person.getIP(Id);
+      return models.Person.getIP(Id, args);
     },
     phoneNumbers: (
       { Id },
       _,
-      { models } // tslint:disable-line
+      { models }, // tslint:disable-line
     ) => models.Person.getPhoneNumbersFromId(Id),
     photo: ({ PhotoId }, _, { models }) => {
       if (!PhotoId) {
@@ -108,7 +109,7 @@ export default {
     roles: ({ Id }, { cache = true }, { models }) =>
       models.Person.getGroups(Id, 1), // 1: security groups
     groups: ({ Id }, { cache = true, groupTypeIds = [] }, { models }) =>
-      models.Person.getGroups(Id, groupTypeIds)
+      models.Person.getGroups(Id, groupTypeIds),
   },
 
   PhoneNumber: {
@@ -118,20 +119,20 @@ export default {
     canText: ({ IsMessagingEnabled }) => IsMessagingEnabled,
     rawNumber: ({ Number }) => Number,
     number: ({ NumberFormatted, Number }) => NumberFormatted || Number,
-    person: ({ PersonId }, _, { models }) => models.Person.getFromId(PersonId)
+    person: ({ PersonId }, _, { models }) => models.Person.getFromId(PersonId),
   },
 
   PhoneNumberMutationResponse: {
-    ...MutationReponseResolver
+    ...MutationReponseResolver,
   },
 
   DeviceRegistrationMutationResponse: {
-    ...MutationReponseResolver
+    ...MutationReponseResolver,
   },
 
   AttributeValueMutationResponse: {
-    ...MutationReponseResolver
-  }
+    ...MutationReponseResolver,
+  },
 };
 
 // # home: [Location]

--- a/src/rock/models/people/schema.js
+++ b/src/rock/models/people/schema.js
@@ -25,7 +25,7 @@ export default [
     birthMonth: Int
     birthYear: Int
     email: String
-    impersonationParameter: String
+    impersonationParameter(expireDateTime: String, pageId: Int, usageLimit: Int): String
     campus(cache: Boolean = true): Campus
     home(cache: Boolean = true): Location
     roles(cache: Boolean = true): [Group]
@@ -50,5 +50,5 @@ export default [
     success: Boolean!
     code: Int
   }
-`
+`,
 ];


### PR DESCRIPTION
- updated `impersonationParameter` schema to accept `expireDateTime`, `pageId`, `usageLimit` as arguments.
- updated the resolver to pass in addition args based on the api docs.
- passed the above args with `PersonId` as querystrings to the rock API.

# Test Queries

```graphql
  query PersonData {
    person: currentPerson {
      id
      firstName
      nickName
      impersonationParameter
    }
  }
```
and

```graphql
  query PersonData {
    person: currentPerson {
      id
      firstName
      nickName
      impersonationParameter(expireDateTime: "2017-09-03T17:56:26-04:00", pageId: 100, usageLimit: 2)
    }
  }
```

Note: you can leave off any of the querystring params (or empty entirely) and a IP will still be created.

