### PR TITLE
Add video prop to content

### DIFF
--- a/src/expression-engine/models/content/__tests__/resolver.spec.js
+++ b/src/expression-engine/models/content/__tests__/resolver.spec.js
@@ -388,6 +388,19 @@ it("`ContentData` should return ooyalaId", () => {
   expect(ooyalaId).toEqual(mockData.video);
 });
 
+it("`ContentData` should return a video", () => {
+  const { ContentData } = Resolver;
+  const mockData = {
+    video: "id",
+  };
+
+  const video = ContentData.video(mockData);
+  expect(video).toMatchObject({
+    id: mockData.video,
+    embedUrl: expect.stringContaining('player.ooyala.com'),
+  });
+});
+
 it("`ContentData` should call splitByNewLines", () => {
   const { ContentData } = Resolver;
   const mockData = {

--- a/src/expression-engine/models/content/resolver.js
+++ b/src/expression-engine/models/content/resolver.js
@@ -104,7 +104,8 @@ export default {
     description: ({ description }) => description,
     ooyalaId: ({ video }) => video,
     video: ({ video }) => {
-      const pbid = 'ZmJmNTVlNDk1NjcwYTVkMzAzODkyMjg0&pcode=';
+      if (!video) return null;
+      const pbid = 'ZmJmNTVlNDk1NjcwYTVkMzAzODkyMjg0';
       const pcode = 'E1dWM6UGncxhent7MRATc3hmkzUD';
       const playerConfig = 'https%3A%2F%2Fd3n6tjerleuu41.cloudfront.net%2Fnewspring%2Fskin.new.json';
 

--- a/src/expression-engine/models/content/resolver.js
+++ b/src/expression-engine/models/content/resolver.js
@@ -103,6 +103,21 @@ export default {
     body: ({ body, legacy_body }, _, { models }) => models.Content.cleanMarkup(body || legacy_body),
     description: ({ description }) => description,
     ooyalaId: ({ video }) => video,
+    video: ({ video }) => {
+      // Todo: should these be stored as ENV vars?
+      const pbid = 'ZmJmNTVlNDk1NjcwYTVkMzAzODkyMjg0&pcode=';
+      const pcode = 'E1dWM6UGncxhent7MRATc3hmkzUD';
+
+      // Todo: this is hosted on a personal dropbox. Should be moved to S3 or something (needs CORs though)
+      const playerConfig = 'https%3A%2F%2Fdl.dropbox.com%2Fs%2Fsodcv1d9a4ezwm4%2Fskin.new.json%3Fdl%3D1';
+
+      const embedUrl = `https://player.ooyala.com/static/v4/production/latest/skin-plugin/iframe.html?ec=${video}&pbid=${pbid}&pcode=${pcode}&skin.config=${playerConfig}`;
+
+      return ({
+        id: video,
+        embedUrl,
+      });
+    },
     tags: ({ tags }, _, { models }) => models.Content.splitByNewLines(tags),
     speaker: ({ speaker }) => speaker,
     hashtag: ({ hashtag }) => hashtag,

--- a/src/expression-engine/models/content/resolver.js
+++ b/src/expression-engine/models/content/resolver.js
@@ -104,12 +104,9 @@ export default {
     description: ({ description }) => description,
     ooyalaId: ({ video }) => video,
     video: ({ video }) => {
-      // Todo: should these be stored as ENV vars?
       const pbid = 'ZmJmNTVlNDk1NjcwYTVkMzAzODkyMjg0&pcode=';
       const pcode = 'E1dWM6UGncxhent7MRATc3hmkzUD';
-
-      // Todo: this is hosted on a personal dropbox. Should be moved to S3 or something (needs CORs though)
-      const playerConfig = 'https%3A%2F%2Fdl.dropbox.com%2Fs%2Fsodcv1d9a4ezwm4%2Fskin.new.json%3Fdl%3D1';
+      const playerConfig = 'https%3A%2F%2Fd3n6tjerleuu41.cloudfront.net%2Fnewspring%2Fskin.new.json';
 
       const embedUrl = `https://player.ooyala.com/static/v4/production/latest/skin-plugin/iframe.html?ec=${video}&pbid=${pbid}&pcode=${pcode}&skin.config=${playerConfig}`;
 

--- a/src/expression-engine/models/content/schema.js
+++ b/src/expression-engine/models/content/schema.js
@@ -21,7 +21,8 @@ export default [`
   type ContentData {
     body: String
     description: String
-    ooyalaId: String
+    ooyalaId: String @deprecated(reason: "Use video instead")
+    video: ContentVideo
     speaker: String
     isLight: Boolean
     hashtag: String
@@ -34,6 +35,11 @@ export default [`
     tracks: [File]
     audio: [File]
     scripture: [ContentScripture]
+  }
+
+  type ContentVideo {
+    id: String
+    embedUrl: String
   }
 
   type ContentMeta {


### PR DESCRIPTION
Adds a `video` prop to `ContentData`.
Note: built this blindly, untested.

Currently returns an `embedUrl` pointing out an `html` embeddable player. We can use this to abstract the ooyala integration, but keep all of ooyala's customizations and analytics events.

If we don't care about those - I can add a `videoUrl` prop instead and potentially point to the video resource, but I might need insight on how we can generate that link.

@Lepozepo thoughts on this?

Currently a few todos in the code... need to be addressed.