### PR TITLE
197a migration script

### DIFF
--- a/mongoMigrations/.gitignore
+++ b/mongoMigrations/.gitignore
@@ -1,0 +1,2 @@
+data
+dump

--- a/mongoMigrations/v2up.js
+++ b/mongoMigrations/v2up.js
@@ -41,9 +41,9 @@ MongoClient.connect(url, async function (err, client) {
   await userTopicsAggCursor.toArray();
 
   // User Likes
-  await db.collection("likes").rename("old_likes");
+  // await db.collection("likes").rename("old_likes");
 
-  const Likes = db.collection("old_likes");
+  const Likes = db.collection("likes");
   const userLikesAggCursor = await Likes.aggregate([
     {
       $lookup: {
@@ -66,7 +66,7 @@ MongoClient.connect(url, async function (err, client) {
       }
     },
     {
-      $out: "likes",
+      $out: "new_likes",
     },
   ]);
   await userLikesAggCursor.toArray();

--- a/mongoMigrations/v2up.js
+++ b/mongoMigrations/v2up.js
@@ -71,10 +71,14 @@ MongoClient.connect(url, async function (err, client) {
   ]);
   await userLikesAggCursor.toArray();
 
-  Likes.find().forEach(function(doc) {
-    doc.createdAt = new Date(doc.createdAt);
-    db.Likes.save(doc);
-  });
+  var cursor = Likes.find();
+  while (cursor.hasNext()) {
+    var doc = cursor.next();
+    Likes.update(
+        {"_id" : doc._id},
+        {"$set" : {"createdAt" : new ISODate(doc.createdAt)}}
+      )
+  };
 
   client.close();
 });

--- a/mongoMigrations/v2up.js
+++ b/mongoMigrations/v2up.js
@@ -61,11 +61,7 @@ MongoClient.connect(url, async function (err, client) {
         _id: 1,
         userId: "$user.services.rock.PrimaryAliasId",
         entryId: 1,
-        createdAt: {
-          $dateFromString: {
-             dateString: '$createdAt',
-          }
-        },
+        createdAt: 1,
         __v: { $literal: 0 },
       }
     },
@@ -74,6 +70,11 @@ MongoClient.connect(url, async function (err, client) {
     },
   ]);
   await userLikesAggCursor.toArray();
+
+  Likes.find().forEach(function(doc) {
+    doc.createdAt = new Date(doc.createdAt);
+    db.Likes.save(doc);
+  });
 
   client.close();
 });

--- a/mongoMigrations/v2up.js
+++ b/mongoMigrations/v2up.js
@@ -61,7 +61,11 @@ MongoClient.connect(url, async function (err, client) {
         _id: 1,
         userId: "$user.services.rock.PrimaryAliasId",
         entryId: 1,
-        createdAt: 1,
+        createdAt: {
+          $dateFromString: {
+             dateString: '$createdAt',
+          }
+        },
         __v: { $literal: 0 },
       }
     },
@@ -71,14 +75,17 @@ MongoClient.connect(url, async function (err, client) {
   ]);
   await userLikesAggCursor.toArray();
 
-  var cursor = db.collection("likes").find();
-  while (cursor.hasNext()) {
-    var doc = cursor.next();
+  var cursor = await db.collection("likes").find().toArray();
+
+  let i = 0;
+
+  await cursor.forEach(function(doc) {
     db.collection("likes").update(
         {"_id" : doc._id},
-        {"$set" : {"createdAt" : new ISODate(doc.createdAt)}}
+        {"$set" : {"createdAt" : new Date(doc.createdAt)}}
       )
-  };
-
+    console.log("updated: ", i++);
+  });
+  
   client.close();
 });

--- a/mongoMigrations/v2up.js
+++ b/mongoMigrations/v2up.js
@@ -1,10 +1,10 @@
 const MongoClient = require("mongodb").MongoClient;
 
 // Connection URL
-const url = "mongodb://localhost:27017";
+const url = "mongodb://localhost";
 
 // Database Name
-const dbName = "master";
+const dbName = "name";
 
 // Use connect method to connect to the server
 MongoClient.connect(url, async function (err, client) {
@@ -61,11 +61,7 @@ MongoClient.connect(url, async function (err, client) {
         _id: 1,
         userId: "$user.services.rock.PrimaryAliasId",
         entryId: 1,
-        createdAt: {
-          $dateFromString: {
-             dateString: '$createdAt',
-          }
-        },
+        createdAt: 1,
         __v: { $literal: 0 },
       }
     },
@@ -86,6 +82,6 @@ MongoClient.connect(url, async function (err, client) {
       )
     console.log("updated: ", i++);
   });
-  
+
   client.close();
 });

--- a/mongoMigrations/v2up.js
+++ b/mongoMigrations/v2up.js
@@ -61,7 +61,11 @@ MongoClient.connect(url, async function (err, client) {
         _id: 1,
         userId: "$user.services.rock.PrimaryAliasId",
         entryId: 1,
-        createdAt: 1,
+        createdAt: {
+          $dateFromString: {
+             dateString: '$createdAt',
+          }
+        },
         __v: { $literal: 0 },
       }
     },

--- a/mongoMigrations/v2up.js
+++ b/mongoMigrations/v2up.js
@@ -1,0 +1,75 @@
+const MongoClient = require("mongodb").MongoClient;
+
+// Connection URL
+const url = "mongodb://localhost:27017";
+
+// Database Name
+const dbName = "master";
+
+// Use connect method to connect to the server
+MongoClient.connect(url, async function (err, client) {
+  console.log("Connected successfully to server");
+
+  const db = client.db(dbName);
+
+  // Users Topics
+  const Users = db.collection("users");
+  const userTopicsAggCursor = await Users.aggregate([
+    {
+      $match: {
+        "topics.0": { $exists: true },
+      },
+    },
+    {
+      $unwind: "$topics",
+    },
+    {
+      $project: {
+        _id: {
+          $concat: ["$_id", "$topics"],
+        },
+        userId: "$services.rock.PrimaryAliasId",
+        topic: "$topics",
+        __v: { $literal: 0 },
+      },
+    },
+    {
+      $out: "user_ignored_topics",
+    },
+  ]);
+
+  await userTopicsAggCursor.toArray();
+
+  // User Likes
+  await db.collection("likes").rename("old_likes");
+
+  const Likes = db.collection("old_likes");
+  const userLikesAggCursor = await Likes.aggregate([
+    {
+      $lookup: {
+        from: "users",
+        localField: "userId",
+        foreignField: "_id",
+        as: "user",
+      },
+    },
+    {
+      $unwind: "$user",
+    },
+    {
+      $project: {
+        _id: 1,
+        userId: "$user.services.rock.PrimaryAliasId",
+        entryId: 1,
+        createdAt: 1,
+        __v: { $literal: 0 },
+      }
+    },
+    {
+      $out: "likes",
+    },
+  ]);
+  await userLikesAggCursor.toArray();
+
+  client.close();
+});

--- a/mongoMigrations/v2up.js
+++ b/mongoMigrations/v2up.js
@@ -41,9 +41,9 @@ MongoClient.connect(url, async function (err, client) {
   await userTopicsAggCursor.toArray();
 
   // User Likes
-  // await db.collection("likes").rename("old_likes");
+  await db.collection("likes").rename("old_likes");
 
-  const Likes = db.collection("likes");
+  const Likes = db.collection("old_likes");
   const userLikesAggCursor = await Likes.aggregate([
     {
       $lookup: {
@@ -66,7 +66,7 @@ MongoClient.connect(url, async function (err, client) {
       }
     },
     {
-      $out: "new_likes",
+      $out: "likes",
     },
   ]);
   await userLikesAggCursor.toArray();

--- a/mongoMigrations/v2up.js
+++ b/mongoMigrations/v2up.js
@@ -71,10 +71,10 @@ MongoClient.connect(url, async function (err, client) {
   ]);
   await userLikesAggCursor.toArray();
 
-  var cursor = Likes.find();
+  var cursor = db.collection("likes").find();
   while (cursor.hasNext()) {
     var doc = cursor.next();
-    Likes.update(
+    db.collection("likes").update(
         {"_id" : doc._id},
         {"$set" : {"createdAt" : new ISODate(doc.createdAt)}}
       )

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "ghooks": "^1.2.3",
     "graphql-tester": "0.0.4",
     "jest": "^19.0.0",
+    "mongodb": "^3.0.2",
     "npm-install-webpack-plugin": "^4.0.5",
     "react-test-renderer": "^15.4.1",
     "redis-mock": "^0.16.0",

--- a/src/expression-engine/models/content/__tests__/resolver.spec.js
+++ b/src/expression-engine/models/content/__tests__/resolver.spec.js
@@ -394,11 +394,19 @@ it("`ContentData` should return a video", () => {
     video: "id",
   };
 
-  const video = ContentData.video(mockData);
-  expect(video).toMatchObject({
-    id: mockData.video,
-    embedUrl: expect.stringContaining('player.ooyala.com'),
-  });
+  const mockModels = {
+    Content: {
+      getContentVideo: jest.fn(),
+    },
+  };
+
+  ContentData.video(mockData, undefined, { models: mockModels });
+  expect(mockModels.Content.getContentVideo).toBeCalledWith(mockData.video);
+
+  // expect(video).toMatchObject({
+  //   id: mockData.video,
+  //   embedUrl: expect.stringContaining('player.ooyala.com'),
+  // });
 });
 
 it("`ContentData` should call splitByNewLines", () => {

--- a/src/rock/models/feeds/__tests__/__snapshots__/queries.js.snap
+++ b/src/rock/models/feeds/__tests__/__snapshots__/queries.js.snap
@@ -4,10 +4,11 @@ exports[`Feeds Queries has all needed queries 1`] = `
 Array [
   "userFeed(
     filters: [String]!
-    limit: Int = 20,
-    skip: Int = 0,
-    status: String = \\"open\\",
+    limit: Int = 20
+    skip: Int = 0
+    status: String = \\"open\\"
     cache: Boolean = true
+    options: String = \\"{}\\"
   ): [Node]",
 ]
 `;

--- a/src/rock/models/feeds/queries.js
+++ b/src/rock/models/feeds/queries.js
@@ -4,10 +4,11 @@ export default [
 
   `userFeed(
     filters: [String]!
-    limit: Int = 20,
-    skip: Int = 0,
-    status: String = "open",
+    limit: Int = 20
+    skip: Int = 0
+    status: String = "open"
     cache: Boolean = true
+    options: String = "{}"
   ): [Node]`,
 
 ];

--- a/src/rock/models/likes/model.js
+++ b/src/rock/models/likes/model.js
@@ -11,7 +11,7 @@ const schema = {
   createdAt: String,
 };
 
-const Model = new MongoConnector("like", schema, [
+const Model = new MongoConnector("new_likes", schema, [
   {
     keys: { userId: 1, entryId: 1 },
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4368,6 +4368,13 @@ mongodb-core@2.1.17:
     bson "~1.0.4"
     require_optional "~1.0.0"
 
+mongodb-core@3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/mongodb-core/-/mongodb-core-3.0.2.tgz#914896092dd45427d9a4f98a7997a0bfb81d163b"
+  dependencies:
+    bson "~1.0.4"
+    require_optional "^1.0.1"
+
 mongodb@2.2.33:
   version "2.2.33"
   resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-2.2.33.tgz#b537c471d34a6651b48f36fdbf29750340e08b50"
@@ -4375,6 +4382,12 @@ mongodb@2.2.33:
     es6-promise "3.2.1"
     mongodb-core "2.1.17"
     readable-stream "2.2.7"
+
+mongodb@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-3.0.2.tgz#28172302ed4e9388d8091e2cc4618057e6f5debc"
+  dependencies:
+    mongodb-core "3.0.2"
 
 mongoose@^4.5.8:
   version "4.13.6"
@@ -5495,7 +5508,7 @@ require-uncached@^1.0.2:
     caller-path "^0.1.0"
     resolve-from "^1.0.0"
 
-require_optional@~1.0.0:
+require_optional@^1.0.1, require_optional@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/require_optional/-/require_optional-1.0.1.tgz#4cf35a4247f64ca3df8c2ef208cc494b1ca8fc2e"
   dependencies:


### PR DESCRIPTION
## How to run:

- Go to `mongoMigrations/v2up.js`
- Modify line 4 to match production
- Run `node v2up.js`

## What does it do?
- It replaces userId's in likes for PrimaryAliasId's
- It moves topics to it's own collection

## What it's missing
- v2down.js to go back down
- A decent library to keep track of migrations
