### PR TITLE
Remove wistia api calls

### DIFF
--- a/src/expression-engine/models/content/__tests__/resolver.spec.js
+++ b/src/expression-engine/models/content/__tests__/resolver.spec.js
@@ -401,13 +401,11 @@ it("`ContentData` should return a video", () => {
     },
   };
 
-  ContentData.video(mockData, undefined, { models: mockModels });
-  expect(mockModels.Content.getContentVideo).toBeCalledWith(mockData.video);
+  const video = ContentData.video(mockData, undefined, { models: mockModels });
 
-  // expect(video).toMatchObject({
-  //   id: mockData.video,
-  //   embedUrl: expect.stringContaining('player.ooyala.com'),
-  // });
+  expect(video).toMatchObject({
+    hashed_id: mockData.video,
+  });
 });
 
 it("`ContentData` should call splitByNewLines", () => {

--- a/src/expression-engine/models/content/resolver.js
+++ b/src/expression-engine/models/content/resolver.js
@@ -129,12 +129,11 @@ export default {
   },
 
   ContentVideo: {
-    id: video => video || null,
-    embedUrl: video => // eslint-disable-line
-      video ? `http://fast.wistia.net/embed/iframe/${video}` : null,
-    videoUrl: () => null,
-    // todo: re-enable
-    //  assets ? (assets.find(({ type }) => type === "HdMp4VideoFile") || {}).url : null,
+    id: ({ hashed_id }) => hashed_id || null,
+    embedUrl: ({ hashed_id }) => // eslint_disable_line
+      hashed_id ? `http://fast.wistia.net/embed/iframe/${hashed_id}` : null,
+    videoUrl: ({ assets = [] }) =>
+      assets ? (assets.find(({ type }) => type === "HdMp4VideoFile") || {}).url : null,
   },
 
   ContentData: {
@@ -142,7 +141,7 @@ export default {
     description: ({ description }) => description,
     ooyalaId: ({ video }) => video,
     wistiaId: ({ video }) => video,
-    video: ({ video }) => video,
+    video: ({ video }) => ({ hashed_id: video }),
     tags: ({ tags }, _, { models }) => models.Content.splitByNewLines(tags),
     speaker: ({ speaker }) => speaker,
     hashtag: ({ hashtag }) => hashtag,

--- a/src/expression-engine/models/content/resolver.js
+++ b/src/expression-engine/models/content/resolver.js
@@ -129,11 +129,12 @@ export default {
   },
 
   ContentVideo: {
-    id: ({ hashed_id }) => hashed_id || null,
-    embedUrl: ({ hashed_id }) =>
-      hashed_id ? `http://fast.wistia.net/embed/iframe/${hashed_id}` : null,
-    videoUrl: ({ assets }) =>
-      assets ? (assets.find(({ type }) => type === "HdMp4VideoFile") || {}).url : null,
+    id: video => video || null,
+    embedUrl: video => // eslint-disable-line
+      video ? `http://fast.wistia.net/embed/iframe/${video}` : null,
+    videoUrl: () => null,
+    // todo: re-enable
+    //  assets ? (assets.find(({ type }) => type === "HdMp4VideoFile") || {}).url : null,
   },
 
   ContentData: {
@@ -141,7 +142,7 @@ export default {
     description: ({ description }) => description,
     ooyalaId: ({ video }) => video,
     wistiaId: ({ video }) => video,
-    video: ({ video }, _, { models }) => models.Content.getContentVideo(video),
+    video: ({ video }) => video,
     tags: ({ tags }, _, { models }) => models.Content.splitByNewLines(tags),
     speaker: ({ speaker }) => speaker,
     hashtag: ({ hashtag }) => hashtag,


### PR DESCRIPTION
This PR removes calls to the Wistia API that were added so that we can generate a URL to a video file. This would be used for native video playing (https://github.com/NewSpring/Apollos/pull/334).

It appears that the Wistia API periodically returns error messages. I believe this might be due to throttle / call limitations imposed by the Wistia API. So, this PR effectively disables the `videoUrl` prop and makes it always return `null`. Since `videoUrl` is `nullable` according to the graphql schema, this is an acceptable response. Eventually, we should re-enable this property with proper caching on the Wistia API. But as long as we maintain a web-based player, it's not needed.