### PR TITLE
use FOLLOWABLE_TOPICS constant if not logged in

### DIFF
--- a/src/apollos/models/users/model.js
+++ b/src/apollos/models/users/model.js
@@ -386,6 +386,7 @@ export class User {
   }
 
   async getUserFollowingTopics(userId) {
+    if (!userId) return FOLLOWABLE_TOPICS;
     try {
       const ignoredTopicObjects = await this.ignoredTopics.find({
         userId,


### PR DESCRIPTION
Very simple change. Essentially now `getUserFollowingTopics` is called to determine what topics to query for by default in the `homeFeed`. Previously, Holtzman was handling this logic itself - by either manually query for user topics AND THEN querying for the home feed, or just querying for an explicity list of topics. Now, we let Heighliner drive that logic. However, this function is being called even when there's no user. I believe this was working for some time on the beta/alpha environments, but for some reason, there appears to be a record in mongo with a `null` userId. That User happens to only follow Devotionals, Series, and a few others. It's likely bad data left over in production from some time long forgotten. Locally we don't have this bad data, which means the query triggers an error which is caught by our try/catch and `FOLLOWABLE_TOPICS` are returned.

Instead of hunting down the bad data, I'm fixing the code to do what it really should be doing...if the function is called with no `userId`, just return `FOLLOWABLE_TOPICS` immediately. 