### PR TITLE
Patch colan-less auth tokens (looking at you Edge)

### DIFF
--- a/src/routes/graphql.js
+++ b/src/routes/graphql.js
@@ -118,26 +118,17 @@ export default function (app, monitor) {
       if (datadog) datadog.increment("graphql.authenticated.request");
       // bind the logged in user to the context overall
       try {
-        const tokenIsBasicAuth = context.authToken.indexOf("::") >= 0;
-        if (tokenIsBasicAuth) {
-          context.user = await timeout(createdModels.User.getByBasicAuth(context.authToken), 5000);
-          const person = await timeout(
-            createdModels.User.getUserProfile(context.user.PersonId), 5000);
+        if (context.authToken.indexOf("::") < 0) {
+          context.authToken = `::${context.authToken}`;
+        };
+        context.user = await timeout(createdModels.User.getByBasicAuth(context.authToken), 5000);
+        const person = await timeout(
+          createdModels.User.getUserProfile(context.user.PersonId), 5000);
 
-          context.person = await timeout(
-            createdModels.Person.getFromAliasId(
-              person.PrimaryAliasId,
-            ), 5000);
-        } else {
-          // Deprecate
-          context.user = await timeout(
-            createdModels.User.getByHashedToken(context.authToken), 1000);
-
-          context.person = await timeout(
-            createdModels.Person.getFromAliasId(
-              context.user.services.rock.PrimaryAliasId,
-            ), 1000);
-        }
+        context.person = await timeout(
+          createdModels.Person.getFromAliasId(
+            person.PrimaryAliasId,
+          ), 5000);
       } catch (e) {
         /* tslint:disable-line */
       }


### PR DESCRIPTION
This formally removes support for the old login method of using hashed tokens (at one point used by Holtzman). Our new tokens begin with `::` and we were detecting which authentication method to use by the presence of `::` at the beginning of the token. However, it appears that Microsoft Edge heavily parses request headers before they are sent, and there is no way to have Microsoft Edge include `::` at the beginning of a header (atleast that I could determine). 

So, this PR  removes the old method of authentication, and appends `::` characters if the auth token doesn't already have them.

You can thank Microsoft.