### PR TITLE
Remove Fuse Church Online

### DIFF
--- a/src/expression-engine/models/content/__tests__/model.js
+++ b/src/expression-engine/models/content/__tests__/model.js
@@ -5,24 +5,8 @@ import { ChannelData } from "../tables";
 const newSpringLive = [
   {
     isLive: 1,
-    site: "newspring",
     entry_id: "12345",
     status: "just newspring",
-  },
-];
-
-const fuseLive = [
-  {
-    isLive: 1,
-    site: "newspring",
-    entry_id: "12345",
-    status: "newspring",
-  },
-  {
-    isLive: 1,
-    site: "fuse",
-    entry_id: "12345",
-    status: "fuse",
   },
 ];
 
@@ -53,7 +37,7 @@ describe("getLiveStream", () => {
   });
 
   it("should call getIsLive", async () => {
-    Model.getIsLive = jest.fn(() => Promise.resolve({ isLive: true, isFuse: false }));
+    Model.getIsLive = jest.fn(() => Promise.resolve({ isLive: true }));
     await Model.getLiveStream();
     expect(Model.getIsLive).toBeCalled();
   });
@@ -83,29 +67,15 @@ describe("getIsLive", () => {
     const res = await Model.getIsLive();
     expect(res).toEqual({
       isLive: 1,
-      site: "newspring",
       entry_id: "12345",
       status: "just newspring",
-      isFuse: false,
     });
   });
 
-  it("should show Fuse is live correctly", async () => {
-    Model.cache.get = jest.fn(() => Promise.resolve(fuseLive));
-    const res = await Model.getIsLive();
-    expect(res).toEqual({
-      isLive: 1,
-      site: "fuse",
-      entry_id: "12345",
-      status: "fuse",
-      isFuse: true,
-    });
-  });
-
-  it("should nothing is live correctly", async () => {
+  it("should show nothing is live correctly", async () => {
     Model.cache.get = jest.fn(() => Promise.resolve([]));
     const res = await Model.getIsLive();
-    expect(res).toEqual(null);
+    expect(res).toEqual(undefined);
   });
 });
 

--- a/src/expression-engine/models/content/__tests__/resolver.spec.js
+++ b/src/expression-engine/models/content/__tests__/resolver.spec.js
@@ -5,7 +5,6 @@ import Resolver from "../resolver";
 const sampleData = {
   live: {
     isLive: true,
-    isFuse: false,
   },
   contentColor: {
     id: "theId",
@@ -285,14 +284,6 @@ it("`LiveFeed` should return the live flag", () => {
   const isLive = LiveFeed.live(sampleData.live);
 
   expect(isLive).toEqual(sampleData.live.isLive);
-});
-
-it("`LiveFeed` should return the fuse flag", () => {
-  const { LiveFeed } = Resolver;
-
-  const isFuse = LiveFeed.fuse(sampleData.live);
-
-  expect(isFuse).toEqual(sampleData.live.isFuse);
 });
 
 it("`ContentColor` returns the color id", () => {

--- a/src/expression-engine/models/content/model.js
+++ b/src/expression-engine/models/content/model.js
@@ -252,8 +252,8 @@ export class Content extends EE {
 
   async getLiveStream() {
     return this.getIsLive()
-      .then(x => (!x ? { isLive: false, isFuse: false } : x))
-      .then(({ isLive, isFuse }) => ({ isLive, isFuse }));
+      .then(x => (!x ? { isLive: true } : x))
+      .then(({ isLive }) => ({ isLive }));
   }
 
   async getContentVideo(id) {
@@ -271,17 +271,15 @@ export class Content extends EE {
   }
 
   async getIsLive() {
-    return (
-      this.cache
-        .get(
-          "newspring:live",
-          () =>
-            ChannelData.db.query(
-              `
+    return this.cache
+      .get(
+        "newspring:live",
+        () =>
+          ChannelData.db.query(
+            `
       SELECT
         ((WEEKDAY(CONVERT_TZ(NOW(),'+00:00','America/Detroit')) + 1) % 7) = m.col_id_366
             AND (SELECT DATE_FORMAT(CONVERT_TZ(NOW(),'+00:00','America/Detroit'),'%H%i') TIMEONLY) BETWEEN m.col_id_367 AND m.col_id_368 AS isLive,
-            m.col_id_365 as "site",
             d.entry_id,
             t.status
       FROM
@@ -295,32 +293,11 @@ export class Content extends EE {
         AND (t.expiration_date = 0 OR t.expiration_date >= UNIX_TIMESTAMP())
         AND m.col_id_366 IS NOT NULL;
     `,
-              { type: Sequelize.QueryTypes.SELECT },
-            ),
-          { ttl: 60 },
-        )
-        // .then(x => find(x, { isLive: 1 })) // This is what used to be here.
-        .then((x) => {
-          // get all of the array items that are currently live
-          const liveItems = filter(x, { isLive: 1 });
-          // see if there are live items that are for Fuse.
-          const fuseItems = find(liveItems, { site: "fuse" });
-          // if fuseItems is not undefined then there is a Fuse item.
-          // Add isFuse = true to the object and return that object.
-          if (fuseItems !== undefined) {
-            fuseItems.isFuse = true;
-            return fuseItems;
-          }
-          // If you've made it this far then there are no fuse items.
-          // Tell the object there is none (isFuse = false), and return the
-          // regular item.
-          if (liveItems.length >= 1) {
-            liveItems[0].isFuse = false;
-            return liveItems[0];
-          }
-          return null;
-        })
-    );
+            { type: Sequelize.QueryTypes.SELECT },
+          ),
+        { ttl: 60 },
+      )
+      .then(x => find(x, { isLive: 1 }));
     // tslint:enable
   }
 

--- a/src/expression-engine/models/content/resolver.js
+++ b/src/expression-engine/models/content/resolver.js
@@ -100,7 +100,6 @@ export default {
 
   LiveFeed: {
     live: ({ isLive }) => !!isLive,
-    fuse: ({ isFuse }) => !!isFuse,
     embedCode: ({ snippet_contents }) => snippet_contents,
     embedUrl: ({ snippet_contents: video }) => {
       // video = 'V1a2xxZDE6g-BJTbHZEU8N37nDPFFWq1';
@@ -130,8 +129,9 @@ export default {
 
   ContentVideo: {
     id: ({ hashed_id }) => hashed_id || null,
-    embedUrl: ({ hashed_id }) => // eslint_disable_line
-      hashed_id ? `http://fast.wistia.net/embed/iframe/${hashed_id}` : null,
+    embedUrl: (
+      { hashed_id }, // eslint_disable_line
+    ) => (hashed_id ? `http://fast.wistia.net/embed/iframe/${hashed_id}` : null),
     videoUrl: ({ assets = [] }) =>
       assets ? (assets.find(({ type }) => type === "HdMp4VideoFile") || {}).url : null,
   },

--- a/src/expression-engine/models/content/schema.js
+++ b/src/expression-engine/models/content/schema.js
@@ -2,7 +2,6 @@ export default [
   `
   type LiveFeed {
     live: Boolean!
-    fuse: Boolean!
     embedCode: String
     embedUrl: String
     videoUrl: String


### PR DESCRIPTION
- This PR removes anything added for returning whether or not the item that is "live" is for Fuse specifically. It should just return `isLive = true` when there is an event in EE that is live.