### PR TITLE
(SYS-4595) Added safety check

### DIFF
--- a/src/rock/models/groups/resolver.js
+++ b/src/rock/models/groups/resolver.js
@@ -289,6 +289,7 @@ export default {
     active: ({ IsActive }) => IsActive,
     ageRange: resolveAttribute(691, (x = []) => {
       // don't consider [0,0] an age range
+      if (x === null) x = [];
       const hasAgeRange =
         x.length && x.reduce((start, finish) => start && finish);
       if (!hasAgeRange) return null;


### PR DESCRIPTION
Heighliner is exception'ing out when this mysterious age range is being passed in as `null`. This adds a safety check.

Here's the sentry error that keeps happening. https://sentry.io/newspring-church/apollos/issues/754569389/?query=is%3Aunresolved